### PR TITLE
Issue 13: PrettyTimeConverter JSF not locale aware

### DIFF
--- a/src/main/java/com/ocpsoft/pretty/time/web/jsf/PrettyTimeConverter.java
+++ b/src/main/java/com/ocpsoft/pretty/time/web/jsf/PrettyTimeConverter.java
@@ -1,20 +1,33 @@
 package com.ocpsoft.pretty.time.web.jsf;
 
-import java.io.Serializable;
-import java.util.Date;
+import com.ocpsoft.pretty.time.PrettyTime;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
-
-import com.ocpsoft.pretty.time.PrettyTime;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 public class PrettyTimeConverter implements Converter, Serializable
 {
-    private static final long serialVersionUID = 7690470362440868259L;
+    private static final long serialVersionUID = 7690470362440868260L;
 
-    private static PrettyTime prettyTime = new PrettyTime();
+    private static final int MAX_CACHE_SIZE = 20;
+
+    // Cache PrettyTime per locale. LRU cache to prevent memory leak.
+    private static final Map<Locale, PrettyTime> PRETTY_TIME_LOCALE_MAP = new LinkedHashMap<Locale, PrettyTime>(MAX_CACHE_SIZE + 1, 1.1F, true)
+    {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Locale, PrettyTime> eldest)
+        {
+            return size() > MAX_CACHE_SIZE;
+        }
+    };
+
 
     public Object getAsObject(final FacesContext context, final UIComponent comp, final String value)
     {
@@ -25,27 +38,22 @@ public class PrettyTimeConverter implements Converter, Serializable
     {
         if (value instanceof Date)
         {
+            PrettyTime prettyTime;
+
+            // Use locale of current viewer.
+            Locale locale = context.getViewRoot().getLocale();
+
+            synchronized (PRETTY_TIME_LOCALE_MAP)
+            {
+                prettyTime = PRETTY_TIME_LOCALE_MAP.get(locale);
+                if (prettyTime == null)
+                {
+                    prettyTime = new PrettyTime(locale);
+                    PRETTY_TIME_LOCALE_MAP.put(locale, prettyTime);
+                }
+            }
             return prettyTime.format((Date) value);
         }
-        throw new ConverterException("May only be used to convert java.util.Date objects. Got: " + value.getClass());
+        throw new ConverterException("May only be used to convert java.util.Date objects. Got: " + (value != null ? value.getClass() : "null"));
     }
-
-    /**
-     * Get the current {@link PrettyTime} instance being used in this Converter
-     * @return
-     */
-    public static PrettyTime getPrettyTime()
-    {
-        return prettyTime;
-    }
-
-    /**
-     * Set the current {@link PrettyTime} instance being used in this Converter
-     * @param prettyTime
-     */
-    public static void setPrettyTime(PrettyTime prettyTime)
-    {
-        PrettyTimeConverter.prettyTime = prettyTime;
-    }
-
 }


### PR DESCRIPTION
JSF PrettyTimeConverter is not aware of the current viewers locale. 
By default it uses the system locale, which doesn't have to be the locale of the current viewer.

I made some modifications to PrettyTimeConverter.java. Now it applies the expected locale for the current viewer. It uses a cache per locale for PrettyTime to prevent expensive object creation. The cache size is maximized to prevent a memory leak.

I had to remove both methods getPrettyTime() and setPrettyTime because they make no sense anymore.

BTW, this is my first GitHub experience.
