### PR TITLE
Problem fixed with literal "JustNowPastPrefix"

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ca.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ca.java
@@ -52,7 +52,7 @@ public class Resources_ca extends ListResourceBundle
                                                               { "JustNowPattern", "%u" },
                                                               { "JustNowFuturePrefix", "" },
                                                               { "JustNowFutureSuffix", "en un instant" },
-                                                              { "JustNowPastPrefix", "en uns instants" },
+                                                              { "JustNowPastPrefix", "fa uns instants" },
                                                               { "JustNowPastSuffix", "" },
                                                               { "JustNowSingularName", "" },
                                                               { "JustNowPluralName", "" },


### PR DESCRIPTION
The translation was "en uns instants" and it must be "fa uns instants".
