### PR TITLE
yesterday isn't parsed correctly

### DIFF
--- a/nlp/src/test/java/org/ocpsoft/prettytime/nlp/PrettyTimeParserTest.java
+++ b/nlp/src/test/java/org/ocpsoft/prettytime/nlp/PrettyTimeParserTest.java
@@ -1,15 +1,14 @@
 package org.ocpsoft.prettytime.nlp;
 
+import junit.framework.Assert;
+import org.junit.Test;
+import org.ocpsoft.prettytime.PrettyTime;
+import org.ocpsoft.prettytime.nlp.parse.DateGroup;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-
-import junit.framework.Assert;
-
-import org.junit.Test;
-import org.ocpsoft.prettytime.PrettyTime;
-import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
 public class PrettyTimeParserTest
 {
@@ -78,4 +77,21 @@ public class PrettyTimeParserTest
       Assert.assertEquals(1000 * 60 * 60 * 24 * 3, parse.get(0).getRecurInterval(), 1d);
    }
 
+    @Test
+    public void testParseYesterday()
+    {
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.setTime(new Date());
+        yesterday.add(Calendar.DAY_OF_MONTH, -1);
+
+        List<Date> parse = new PrettyTimeParser().parse("yesterday");
+        Assert.assertFalse(parse.isEmpty());
+
+        Calendar parsedDate = Calendar.getInstance();
+        parsedDate.setTime(parse.get(0));
+
+        Assert.assertEquals(yesterday.get(Calendar.DAY_OF_MONTH), parsedDate.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(yesterday.get(Calendar.MONTH), parsedDate.get(Calendar.MONTH));
+        Assert.assertEquals(yesterday.get(Calendar.YEAR), parsedDate.get(Calendar.YEAR));
+    }
 }


### PR DESCRIPTION
Hi,

Using `PretyTimeParser.parse("yesterday")` gives you back either today or tomorrow. However if you use `PrettyTimeParser.parseSyntax("yesterday")` you get back the date you would expect.

The issue seems to be with the `relativize()` logic in `parse()` method. As I don't know the full picture behind the relativize logic, I didn't really want to change that method, so I'm at least supplying a failing test.

If you can have a look at it, that would be great as I really like using this project!

Cheers,
Michal
