### PR TITLE
Fix issue #56 (infinite loop) in calculateDuration

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
@@ -172,13 +172,14 @@ public class PrettyTime
             if (millisPerUnit > absoluteDifference)
             {
                // we are rounding up: get 1 or -1 for past or future
-               result.setQuantity(getSign(difference, absoluteDifference));
+               result.setQuantity(getSign(difference));
+               result.setDelta(0);
             }
             else
             {
                result.setQuantity(difference / millisPerUnit);
+               result.setDelta(difference - result.getQuantity() * millisPerUnit);
             }
-            result.setDelta(difference - result.getQuantity() * millisPerUnit);
             break;
          }
 
@@ -186,7 +187,7 @@ public class PrettyTime
       return result;
    }
 
-   private long getSign(final long difference, final long absoluteDifference)
+   private long getSign(final long difference)
    {
       if (0 > difference)
       {


### PR DESCRIPTION
Fixes issue #56
- In PrettyTime.calculateDuration(), when the unit was englobing the
  absoluteDifference, the delta was not correctly set. It should be set to
  zero whenever it is englobing the absoluteDifference.
- Removed unused argument in getSign()
