### PR TITLE
Dependency with prettytime should be compile scoped

### DIFF
--- a/jsf/pom.xml
+++ b/jsf/pom.xml
@@ -16,7 +16,6 @@
       <dependency>
          <groupId>org.ocpsoft.prettytime</groupId>
          <artifactId>prettytime</artifactId>
-         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>javax.faces</groupId>


### PR DESCRIPTION
It throws a ClassNotFoundException without it, requiring me to add the prettytime lib 
