### PR TITLE
Fix Japanese translation.

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ja.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ja.java
@@ -1,60 +1,62 @@
 package org.ocpsoft.prettytime.i18n;
 
-import org.ocpsoft.prettytime.Duration;
-import org.ocpsoft.prettytime.TimeFormat;
-import org.ocpsoft.prettytime.TimeUnit;
-import org.ocpsoft.prettytime.impl.TimeFormatProvider;
-
 import java.util.ListResourceBundle;
 import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import org.ocpsoft.prettytime.Duration;
+import org.ocpsoft.prettytime.TimeFormat;
+import org.ocpsoft.prettytime.TimeUnit;
+import org.ocpsoft.prettytime.impl.TimeFormatProvider;
+import org.ocpsoft.prettytime.units.Decade;
+import org.ocpsoft.prettytime.units.Millennium;
 
 public class Resources_ja extends ListResourceBundle implements TimeFormatProvider
 {
    private static final Object[][] OBJECTS = new Object[][] {
             { "CenturyPattern", "%n%u" },
             { "CenturyFuturePrefix", "今から" },
-            { "CenturyFutureSuffix", "世紀にもわたっ" },
+            { "CenturyFutureSuffix", "後" },
             { "CenturyPastPrefix", "" },
-            { "CenturyPastSuffix", "世紀前" },
-            { "CenturySingularName", "" },
-            { "CenturyPluralName", "" },
+            { "CenturyPastSuffix", "前" },
+            { "CenturySingularName", "世紀" },
+            { "CenturyPluralName", "世紀" },
             { "DayPattern", "%n%u" },
             { "DayFuturePrefix", "今から" },
-            { "DayFutureSuffix", "間" },
+            { "DayFutureSuffix", "後" },
             { "DayPastPrefix", "" },
             { "DayPastSuffix", "前" },
             { "DaySingularName", "日" },
             { "DayPluralName", "日" },
             { "DecadePattern", "%n%u" },
             { "DecadeFuturePrefix", "今から" },
-            { "DecadeFutureSuffix", "年間" },
+            { "DecadeFutureSuffix", "後" },
             { "DecadePastPrefix", "" },
-            { "DecadePastSuffix", "年前" },
-            { "DecadeSingularName", "" },
-            { "DecadePluralName", "" },
+            { "DecadePastSuffix", "前" },
+            { "DecadeSingularName", "年" },
+            { "DecadePluralName", "年" },
             { "HourPattern", "%n%u" },
             { "HourFuturePrefix", "今から" },
-            { "HourFutureSuffix", "" },
+            { "HourFutureSuffix", "後" },
             { "HourPastPrefix", "" },
             { "HourPastSuffix", "前" },
             { "HourSingularName", "時間" },
             { "HourPluralName", "時間" },
             { "JustNowPattern", "%u" },
-            { "JustNowFuturePrefix", "" },
-            { "JustNowFutureSuffix", "今からすぐ" },
+            { "JustNowFuturePrefix", "今から" },
+            { "JustNowFutureSuffix", "すぐ" },
             { "JustNowPastPrefix", "" },
-            { "JustNowPastSuffix", "さっき" },
+            { "JustNowPastSuffix", "たった今" },
             { "JustNowSingularName", "" },
             { "JustNowPluralName", "" },
-            { "MillenniumPattern", "%n %u" },
-            { "MillenniumFuturePrefix", "" },
-            { "MillenniumFutureSuffix", "今から" },
+            { "MillenniumPattern", "%n%u" },
+            { "MillenniumFuturePrefix", "今から" },
+            { "MillenniumFutureSuffix", "後" },
             { "MillenniumPastPrefix", "" },
             { "MillenniumPastSuffix", "前" },
-            { "MillenniumSingularName", "千年" },
-            { "MillenniumPluralName", "千年" },
+            { "MillenniumSingularName", "年" },
+            { "MillenniumPluralName", "年" },
             { "MillisecondPattern", "%n%u" },
             { "MillisecondFuturePrefix", "" },
             { "MillisecondFutureSuffix", "今から" },
@@ -64,14 +66,14 @@ public class Resources_ja extends ListResourceBundle implements TimeFormatProvid
             { "MillisecondPluralName", "ミリ秒" },
             { "MinutePattern", "%n%u" },
             { "MinuteFuturePrefix", "今から" },
-            { "MinuteFutureSuffix", "" },
+            { "MinuteFutureSuffix", "後" },
             { "MinutePastPrefix", "" },
             { "MinutePastSuffix", "前" },
             { "MinuteSingularName", "分" },
             { "MinutePluralName", "分" },
             { "MonthPattern", "%n%u" },
             { "MonthFuturePrefix", "今から" },
-            { "MonthFutureSuffix", "" },
+            { "MonthFutureSuffix", "後" },
             { "MonthPastPrefix", "" },
             { "MonthPastSuffix", "前" },
             { "MonthSingularName", "ヶ月" },
@@ -85,18 +87,18 @@ public class Resources_ja extends ListResourceBundle implements TimeFormatProvid
             { "SecondPluralName", "秒" },
             { "WeekPattern", "%n%u" },
             { "WeekFuturePrefix", "今から" },
-            { "WeekFutureSuffix", "週間" },
+            { "WeekFutureSuffix", "後" },
             { "WeekPastPrefix", "" },
-            { "WeekPastSuffix", "週間前" },
-            { "WeekSingularName", "" },
-            { "WeekPluralName", "" },
+            { "WeekPastSuffix", "前" },
+            { "WeekSingularName", "週間" },
+            { "WeekPluralName", "週間" },
             { "YearPattern", "%n%u" },
-            { "YearFuturePrefix", "" },
-            { "YearFutureSuffix", "年後の" },
+            { "YearFuturePrefix", "今から" },
+            { "YearFutureSuffix", "後" },
             { "YearPastPrefix", "" },
-            { "YearPastSuffix", "年前" },
-            { "YearSingularName", "" },
-            { "YearPluralName", "" },
+            { "YearPastSuffix", "前" },
+            { "YearSingularName", "年" },
+            { "YearPluralName", "年" },
             { "AbstractTimeUnitPattern", "" },
             { "AbstractTimeUnitFuturePrefix", "" },
             { "AbstractTimeUnitFutureSuffix", "" },
@@ -199,6 +201,8 @@ public class Resources_ja extends ListResourceBundle implements TimeFormatProvid
          String sign = getSign(duration);
          String unit = getGramaticallyCorrectName(duration, round);
          long quantity = getQuantity(duration, round);
+         if (duration.getUnit() instanceof Decade) quantity *= 10;
+         if (duration.getUnit() instanceof Millennium) quantity *= 1000;
 
          return applyPattern(sign, unit, quantity);
       }
@@ -208,6 +212,7 @@ public class Resources_ja extends ListResourceBundle implements TimeFormatProvid
          String result = getPattern(quantity).replaceAll(SIGN, sign);
          result = result.replaceAll(QUANTITY, String.valueOf(quantity));
          result = result.replaceAll(UNIT, unit);
+
          return result;
       }
 

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_JA_Test.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_JA_Test.java
@@ -61,7 +61,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 12 minutes from now
-      assertEquals("12 minutes from now", "今から12分", t.format(new Date(1000 * 60 * 12)));
+      assertEquals("12 minutes from now", "今から12分後", t.format(new Date(1000 * 60 * 12)));
    }
 
    @Test
@@ -69,7 +69,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 3 hours from now
-      assertEquals("3 hours from now", "今から3時間", t.format(new Date(1000 * 60 * 60 * 3)));
+      assertEquals("3 hours from now", "今から3時間後", t.format(new Date(1000 * 60 * 60 * 3)));
    }
 
    @Test
@@ -77,7 +77,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 3 days from now
-      assertEquals("3 days from now", "今から3日間", t.format(new Date(1000 * 60 * 60 * 24 * 3)));
+      assertEquals("3 days from now", "今から3日後", t.format(new Date(1000 * 60 * 60 * 24 * 3)));
    }
 
    @Test
@@ -85,7 +85,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 3 weeks from now
-      assertEquals("3 weeks from now", "今から3週間", t.format(new Date(1000 * 60 * 60 * 24 * 7 * 3)));
+      assertEquals("3 weeks from now", "今から3週間後", t.format(new Date(1000 * 60 * 60 * 24 * 7 * 3)));
    }
 
    @Test
@@ -93,7 +93,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 3 months from now
-      assertEquals("3 months from now", "今から3ヶ月", t.format(new Date(2629743830L * 3L)));
+      assertEquals("3 months from now", "今から3ヶ月後", t.format(new Date(2629743830L * 3L)));
    }
 
    @Test
@@ -101,7 +101,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 3 years from now
-      assertEquals("3 years from now", "3年後の", t.format(new Date(2629743830L * 12L * 3L)));
+      assertEquals("3 years from now", "今から3年後", t.format(new Date(2629743830L * 12L * 3L)));
    }
 
    @Test
@@ -109,7 +109,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 1 decade from now
-      assertEquals("今から1年間", t.format(new Date(315569259747L * 1L)));
+      assertEquals("今から10年後", t.format(new Date(315569259747L * 1L)));
    }
 
    @Test
@@ -117,7 +117,15 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       // 3 centuries from now
-      assertEquals("3 centuries from now", "今から3世紀にもわたっ", t.format(new Date(3155692597470L * 3L)));
+      assertEquals("3 centuries from now", "今から3世紀後", t.format(new Date(3155692597470L * 3L)));
+   }
+
+   @Test
+   public void testMillenniumFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      // 3 millennia from now
+      assertEquals("3 millennia from now", "今から3000年後", t.format(new Date(3155692597470L * 10L * 3L)));
    }
 
    /*
@@ -128,7 +136,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(6000), locale);
       // moments ago
-      assertEquals("さっき", t.format(new Date(0)));
+      assertEquals("たった今", t.format(new Date(0)));
    }
 
    @Test
@@ -196,7 +204,7 @@ public class PrettyTimeI18n_JA_Test
          {
             return 5000;
          }
-         
+
          @Override
          public boolean isPrecise()
          {
@@ -229,7 +237,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(315569259747L * 1L), locale);
       // 1 decade ago
-      assertEquals("1年前", t.format(new Date(0)));
+      assertEquals("10年前", t.format(new Date(0)));
    }
 
    @Test
@@ -238,6 +246,14 @@ public class PrettyTimeI18n_JA_Test
       PrettyTime t = new PrettyTime(new Date(3155692597470L * 3L), locale);
       // 3 centuries ago
       assertEquals("3 centuries ago", "3世紀前", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMilleniumAgo() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(3155692597470L * 10 * 3L), locale);
+      // 3 millennia ago
+      assertEquals("3 millennia ago", "3000年前", t.format(new Date(0)));
    }
 
    @Test
@@ -275,7 +291,7 @@ public class PrettyTimeI18n_JA_Test
    {
       PrettyTime t = new PrettyTime(new Date(315569259747L * 1L), locale);
       // 1 decade ago
-      assertEquals("1年前", t.format(new Date(0)));
+      assertEquals("10年前", t.format(new Date(0)));
       t.setLocale(Locale.GERMAN);
       assertEquals("vor 1 Jahrzehnt", t.format(new Date(0)));
    }


### PR DESCRIPTION
* One decade is "10年" in Japanese.
* A Millennium is a "千年" in Japanese. However, it is usually referred to as "1000年".