### PR TITLE
Fixed that setLocale method can't change format language

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
@@ -728,6 +728,7 @@ public class PrettyTime
          if (format instanceof LocaleAware)
             ((LocaleAware<?>) format).setLocale(locale);
       }
+      cachedUnits = null;
       return this;
    }
 


### PR DESCRIPTION
It's a bug with mutable cached units. If you call setLocale to change language then cached units is not updated and will return old values (e.g. language don't switches).

Example:
```
PrettyTime t = new PrettyTime(Locale.ENGLISH);
t.setLocale(Locale.FRENCH);        
System.out.println(t.format(new Date())); // error: returns english, but must french
```