### PR TITLE
Fix negative duration in Russian version (#182)

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ru.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ru.java
@@ -36,18 +36,14 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
       public String format(Duration duration)
       {
          long quantity = duration.getQuantityRounded(tolerance);
-         StringBuilder result = new StringBuilder();
-         result.append(quantity);
-         return result.toString();
+         return String.valueOf(quantity);
       }
 
       @Override
       public String formatUnrounded(Duration duration)
       {
-         long quantity = duration.getQuantity();
-         StringBuilder result = new StringBuilder();
-         result.append(quantity);
-         return result.toString();
+         long quantity = Math.abs(duration.getQuantity());
+         return String.valueOf(quantity);
       }
 
       @Override
@@ -66,7 +62,7 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
          return performDecoration(
                   duration.isInPast(),
                   duration.isInFuture(),
-                  duration.getQuantity(),
+                  Math.abs(duration.getQuantity()),
                   time);
       }
 

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_RU_Test.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_RU_Test.java
@@ -140,59 +140,187 @@ public class PrettyTimeI18n_RU_Test
    }
 
    @Test
-   public void testMinutesAgo() throws Exception
+   public void testMinutesAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60), locale);
+      assertEquals("1 минуту назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 минуту назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMinutesAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 3), locale);
+      assertEquals("3 минуты назад", t.formatUnrounded(new Date(0)));
+      assertEquals("3 минуты назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMinutesAgo3() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 12), locale);
+      assertEquals("12 минут назад", t.formatUnrounded(new Date(0)));
       assertEquals("12 минут назад", t.format(new Date(0)));
    }
 
    @Test
-   public void testHoursAgo() throws Exception
+   public void testHoursAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60), locale);
+      assertEquals("1 час назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 час назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testHoursAgo2() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 3), locale);
+      assertEquals("3 часа назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 часа назад", t.format(new Date(0)));
    }
 
    @Test
-   public void testDaysAgo() throws Exception
+   public void testHoursAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 5), locale);
+      assertEquals("5 часов назад", t.formatUnrounded(new Date(0)));
+      assertEquals("5 часов назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDaysAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24), locale);
+      assertEquals("1 день назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 день назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDaysAgo2() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 3), locale);
+      assertEquals("3 дня назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 дня назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDaysAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 5), locale);
+      assertEquals("5 дней назад", t.formatUnrounded(new Date(0)));
+      assertEquals("5 дней назад", t.format(new Date(0)));
    }
 
    @Test
    public void testWeeksAgo() throws Exception
    {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 7), locale);
+      assertEquals("1 неделю назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 неделю назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testWeeksAgo2() throws Exception
+   {
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 7 * 3), locale);
+      assertEquals("3 недели назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 недели назад", t.format(new Date(0)));
    }
 
    @Test
-   public void testMonthsAgo() throws Exception
+   public void testMonthsAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L), locale);
+      assertEquals("1 месяц назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 месяц назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMonthsAgo2() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(2629743830L * 3L), locale);
+      assertEquals("3 месяца назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 месяца назад", t.format(new Date(0)));
    }
 
    @Test
-   public void testYearsAgo() throws Exception
+   public void testMonthsAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 5L), locale);
+      assertEquals("5 месяцев назад", t.formatUnrounded(new Date(0)));
+      assertEquals("5 месяцев назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testYearsAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 12L), locale);
+      assertEquals("1 год назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 год назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testYearsAgo2() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(2629743830L * 12L * 3L), locale);
+      assertEquals("3 года назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 года назад", t.format(new Date(0)));
    }
 
    @Test
-   public void testDecadesAgo() throws Exception
+   public void testYearsAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 12L * 5L), locale);
+      assertEquals("5 лет назад", t.formatUnrounded(new Date(0)));
+      assertEquals("5 лет назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDecadesAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(315569259747L), locale);
+      assertEquals("1 десятилетие назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 десятилетие назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDecadesAgo2() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(315569259747L * 3L), locale);
+      assertEquals("3 десятилетия назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 десятилетия назад", t.format(new Date(0)));
    }
 
    @Test
-   public void testCenturiesAgo() throws Exception
+   public void testDecadesAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(315569259747L * 5L), locale);
+      assertEquals("5 десятилетий назад", t.formatUnrounded(new Date(0)));
+      assertEquals("5 десятилетий назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testCenturiesAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(3155692597470L), locale);
+      assertEquals("1 век назад", t.formatUnrounded(new Date(0)));
+      assertEquals("1 век назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testCenturiesAgo2() throws Exception
    {
       PrettyTime t = new PrettyTime(new Date(3155692597470L * 3L), locale);
+      assertEquals("3 века назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 века назад", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testCenturiesAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(3155692597470L * 5L), locale);
+      assertEquals("5 веков назад", t.formatUnrounded(new Date(0)));
+      assertEquals("5 веков назад", t.format(new Date(0)));
    }
 
    @After


### PR DESCRIPTION
This patch fixes the issue with negative duration values in Russian localization (#182) and adds more tests for different forms of Russian time units.

I just added a call to `Math.abs()` to make `formatUnrounded()` behave like `format()`, where `getQuantityRounded()` drops the sign as well.