### PR TITLE
Updated prettytime.pro

### DIFF
--- a/core/src/main/resources/META-INF/proguard/prettytime.pro
+++ b/core/src/main/resources/META-INF/proguard/prettytime.pro
@@ -1,1 +1,1 @@
--keep class org.ocpsoft.prettytime.i18n.**
+-keep class org.ocpsoft.prettytime.i18n**


### PR DESCRIPTION
In Android Studio 4.0 there is an error with "-keep class org.ocpsoft.prettytime.i18n.**" but it works with "-keep class org.ocpsoft.prettytime.i18n**" ; that is by removing the dot(.) after i18n