### PR TITLE
Fix error in grammatical case for German translations

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/format/SimpleTimeFormat.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/format/SimpleTimeFormat.java
@@ -118,11 +118,15 @@ public class SimpleTimeFormat implements TimeFormat
    protected String getGramaticallyCorrectName(final Duration d, boolean round)
    {
       String result = getSingularName(d);
-      if ((Math.abs(getQuantity(d, round)) == 0) || (Math.abs(getQuantity(d, round)) > 1))
+      if (isPlural(d, round))
       {
          result = getPluralName(d);
       }
       return result;
+   }
+
+   protected boolean isPlural(final Duration d, boolean round) {
+      return (Math.abs(getQuantity(d, round)) == 0) || (Math.abs(getQuantity(d, round)) > 1);
    }
 
    private String getSign(final Duration d)

--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_de.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_de.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,109 +15,162 @@
  */
 package org.ocpsoft.prettytime.i18n;
 
+import org.ocpsoft.prettytime.Duration;
+import org.ocpsoft.prettytime.TimeFormat;
+import org.ocpsoft.prettytime.TimeUnit;
+import org.ocpsoft.prettytime.format.SimpleTimeFormat;
+import org.ocpsoft.prettytime.impl.TimeFormatProvider;
+
+import java.util.Calendar;
 import java.util.ListResourceBundle;
+import java.util.ResourceBundle;
 
-public class Resources_de extends ListResourceBundle
-{
-   private static final Object[][] OBJECTS = new Object[][] {
-            { "CenturyPattern", "%n %u" },
-            { "CenturyFuturePrefix", "in " },
-            { "CenturyFutureSuffix", "" },
-            { "CenturyPastPrefix", "vor " },
-            { "CenturyPastSuffix", "" },
-            { "CenturySingularName", "Jahrhundert" },
-            { "CenturyPluralName", "Jahrhunderten" },
-            { "DayPattern", "%n %u" },
-            { "DayFuturePrefix", "in " },
-            { "DayFutureSuffix", "" },
-            { "DayPastPrefix", "vor " },
-            { "DayPastSuffix", "" },
-            { "DaySingularName", "Tag" },
-            { "DayPluralName", "Tagen" },
-            { "DecadePattern", "%n %u" },
-            { "DecadeFuturePrefix", "in " },
-            { "DecadeFutureSuffix", "" },
-            { "DecadePastPrefix", "vor " },
-            { "DecadePastSuffix", "" },
-            { "DecadeSingularName", "Jahrzehnt" },
-            { "DecadePluralName", "Jahrzehnten" },
-            { "HourPattern", "%n %u" },
-            { "HourFuturePrefix", "in " },
-            { "HourFutureSuffix", "" },
-            { "HourPastPrefix", "vor " },
-            { "HourPastSuffix", "" },
-            { "HourSingularName", "Stunde" },
-            { "HourPluralName", "Stunden" },
-            { "JustNowPattern", "%u" },
-            { "JustNowFuturePrefix", "Jetzt" },
-            { "JustNowFutureSuffix", "" },
-            { "JustNowPastPrefix", "gerade eben" },
-            { "JustNowPastSuffix", "" },
-            { "JustNowSingularName", "" },
-            { "JustNowPluralName", "" },
-            { "MillenniumPattern", "%n %u" },
-            { "MillenniumFuturePrefix", "in " },
-            { "MillenniumFutureSuffix", "" },
-            { "MillenniumPastPrefix", "vor " },
-            { "MillenniumPastSuffix", "" },
-            { "MillenniumSingularName", "Jahrtausend" },
-            { "MillenniumPluralName", "Jahrtausenden" },
-            { "MillisecondPattern", "%n %u" },
-            { "MillisecondFuturePrefix", "in " },
-            { "MillisecondFutureSuffix", "" },
-            { "MillisecondPastPrefix", "vor " },
-            { "MillisecondPastSuffix", "" },
-            { "MillisecondSingularName", "Millisekunde" },
-            { "MillisecondPluralName", "Millisekunden" },
-            { "MinutePattern", "%n %u" },
-            { "MinuteFuturePrefix", "in " },
-            { "MinuteFutureSuffix", "" },
-            { "MinutePastPrefix", "vor " },
-            { "MinutePastSuffix", "" },
-            { "MinuteSingularName", "Minute" },
-            { "MinutePluralName", "Minuten" },
-            { "MonthPattern", "%n %u" },
-            { "MonthFuturePrefix", "in " },
-            { "MonthFutureSuffix", "" },
-            { "MonthPastPrefix", "vor " },
-            { "MonthPastSuffix", "" },
-            { "MonthSingularName", "Monat" },
-            { "MonthPluralName", "Monaten" },
-            { "SecondPattern", "%n %u" },
-            { "SecondFuturePrefix", "in " },
-            { "SecondFutureSuffix", "" },
-            { "SecondPastPrefix", "vor " },
-            { "SecondPastSuffix", "" },
-            { "SecondSingularName", "Sekunde" },
-            { "SecondPluralName", "Sekunden" },
-            { "WeekPattern", "%n %u" },
-            { "WeekFuturePrefix", "in " },
-            { "WeekFutureSuffix", "" },
-            { "WeekPastPrefix", "vor " },
-            { "WeekPastSuffix", "" },
-            { "WeekSingularName", "Woche" },
-            { "WeekPluralName", "Wochen" },
-            { "YearPattern", "%n %u" },
-            { "YearFuturePrefix", "in " },
-            { "YearFutureSuffix", "" },
-            { "YearPastPrefix", "vor " },
-            { "YearPastSuffix", "" },
-            { "YearSingularName", "Jahr" },
-            { "YearPluralName", "Jahren" },
-            { "AbstractTimeUnitPattern", "" },
-            { "AbstractTimeUnitFuturePrefix", "" },
-            { "AbstractTimeUnitFutureSuffix", "" },
-            { "AbstractTimeUnitPastPrefix", "" },
-            { "AbstractTimeUnitPastSuffix", "" },
-            { "AbstractTimeUnitSingularName", "" },
-            { "AbstractTimeUnitPluralName", "" }
+public class Resources_de extends ListResourceBundle implements TimeFormatProvider {
+    private static final Object[][] OBJECTS = new Object[][]{
+            {"CenturyPattern", "%n %u"},
+            {"CenturyFuturePrefix", "in "},
+            {"CenturyFutureSuffix", ""},
+            {"CenturyPastPrefix", "vor "},
+            {"CenturyPastSuffix", ""},
+            {"CenturySingularName", "Jahrhundert"},
+            {"CenturyPluralName", "Jahrhunderte"},
+            {"DayPattern", "%n %u"},
+            {"DayFuturePrefix", "in "},
+            {"DayFutureSuffix", ""},
+            {"DayPastPrefix", "vor "},
+            {"DayPastSuffix", ""},
+            {"DaySingularName", "Tag"},
+            {"DayPluralName", "Tage"},
+            {"DecadePattern", "%n %u"},
+            {"DecadeFuturePrefix", "in "},
+            {"DecadeFutureSuffix", ""},
+            {"DecadePastPrefix", "vor "},
+            {"DecadePastSuffix", ""},
+            {"DecadeSingularName", "Jahrzehnt"},
+            {"DecadePluralName", "Jahrzehnte"},
+            {"HourPattern", "%n %u"},
+            {"HourFuturePrefix", "in "},
+            {"HourFutureSuffix", ""},
+            {"HourPastPrefix", "vor "},
+            {"HourPastSuffix", ""},
+            {"HourSingularName", "Stunde"},
+            {"HourPluralName", "Stunden"},
+            {"JustNowPattern", "%u"},
+            {"JustNowFuturePrefix", "Jetzt"},
+            {"JustNowFutureSuffix", ""},
+            {"JustNowPastPrefix", "gerade eben"},
+            {"JustNowPastSuffix", ""},
+            {"JustNowSingularName", ""},
+            {"JustNowPluralName", ""},
+            {"MillenniumPattern", "%n %u"},
+            {"MillenniumFuturePrefix", "in "},
+            {"MillenniumFutureSuffix", ""},
+            {"MillenniumPastPrefix", "vor "},
+            {"MillenniumPastSuffix", ""},
+            {"MillenniumSingularName", "Jahrtausend"},
+            {"MillenniumPluralName", "Jahrtausende"},
+            {"MillisecondPattern", "%n %u"},
+            {"MillisecondFuturePrefix", "in "},
+            {"MillisecondFutureSuffix", ""},
+            {"MillisecondPastPrefix", "vor "},
+            {"MillisecondPastSuffix", ""},
+            {"MillisecondSingularName", "Millisekunde"},
+            {"MillisecondPluralName", "Millisekunden"},
+            {"MinutePattern", "%n %u"},
+            {"MinuteFuturePrefix", "in "},
+            {"MinuteFutureSuffix", ""},
+            {"MinutePastPrefix", "vor "},
+            {"MinutePastSuffix", ""},
+            {"MinuteSingularName", "Minute"},
+            {"MinutePluralName", "Minuten"},
+            {"MonthPattern", "%n %u"},
+            {"MonthFuturePrefix", "in "},
+            {"MonthFutureSuffix", ""},
+            {"MonthPastPrefix", "vor "},
+            {"MonthPastSuffix", ""},
+            {"MonthSingularName", "Monat"},
+            {"MonthPluralName", "Monate"},
+            {"SecondPattern", "%n %u"},
+            {"SecondFuturePrefix", "in "},
+            {"SecondFutureSuffix", ""},
+            {"SecondPastPrefix", "vor "},
+            {"SecondPastSuffix", ""},
+            {"SecondSingularName", "Sekunde"},
+            {"SecondPluralName", "Sekunden"},
+            {"WeekPattern", "%n %u"},
+            {"WeekFuturePrefix", "in "},
+            {"WeekFutureSuffix", ""},
+            {"WeekPastPrefix", "vor "},
+            {"WeekPastSuffix", ""},
+            {"WeekSingularName", "Woche"},
+            {"WeekPluralName", "Wochen"},
+            {"YearPattern", "%n %u"},
+            {"YearFuturePrefix", "in "},
+            {"YearFutureSuffix", ""},
+            {"YearPastPrefix", "vor "},
+            {"YearPastSuffix", ""},
+            {"YearSingularName", "Jahr"},
+            {"YearPluralName", "Jahre"},
+            {"AbstractTimeUnitPattern", ""},
+            {"AbstractTimeUnitFuturePrefix", ""},
+            {"AbstractTimeUnitFutureSuffix", ""},
+            {"AbstractTimeUnitPastPrefix", ""},
+            {"AbstractTimeUnitPastSuffix", ""},
+            {"AbstractTimeUnitSingularName", ""},
+            {"AbstractTimeUnitPluralName", ""}
 
-   };
+    };
 
-   @Override
-   protected Object[][] getContents()
-   {
-      return OBJECTS;
-   }
+    @Override
+    protected Object[][] getContents() {
+        return OBJECTS;
+    }
+
+
+    @Override
+    public TimeFormat getFormatFor(TimeUnit t) {
+        return new DeTimeFormat(this, t, t.getClass().getSimpleName());
+    }
+
+    private static class DeTimeFormat extends SimpleTimeFormat implements TimeFormat {
+
+        private final TimeUnit unit;
+        private final ResourceBundle bundle;
+
+        public DeTimeFormat(final ResourceBundle bundle, final TimeUnit unit, String prefix) {
+            this.bundle = bundle;
+            this.unit = unit;
+
+            setPattern(bundle.getString(prefix + "Pattern"));
+            setFuturePrefix(bundle.getString(prefix + "FuturePrefix"));
+            setFutureSuffix(bundle.getString(prefix + "FutureSuffix"));
+            setPastPrefix(bundle.getString(prefix + "PastPrefix"));
+            setPastSuffix(bundle.getString(prefix + "PastSuffix"));
+            setSingularName(bundle.getString(prefix + "SingularName"));
+            setPluralName(bundle.getString(prefix + "PluralName"));
+        }
+
+        @Override
+        public String decorate(Duration duration, String time) {
+            // Change the nominative plural to dative by appending an "n" (Tage -> Tagen / Monate -> Monaten)
+            if (isPlural(duration, true)) {
+                if (time != null && time.trim().length() > 0 && !time.endsWith("n")) {
+                    time += "n";
+                }
+            }
+            return super.decorate(duration, time);
+        }
+
+        @Override
+        public String decorateUnrounded(Duration duration, String time) {
+            // Change the nominative plural to dative by appending an "n" (Tage -> Tagen / Monate -> Monaten)
+            if (isPlural(duration, false)) {
+                if (time != null && time.trim().length() > 0 && !time.endsWith("n")) {
+                    time += "n";
+                }
+            }
+            return super.decorateUnrounded(duration, time);
+        }
+    }
 
 }

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_DE_Test.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_DE_Test.java
@@ -27,9 +27,47 @@ public class PrettyTimeI18n_DE_Test {
     }
 
     @Test
+    public void testGrammaticalCaseMilliseconds() {
+        assertEquals("gerade eben", prettyTime.format(addTime(-5, Calendar.MILLISECOND)));
+        assertEquals("gerade eben", prettyTime.format(addTime(-1, Calendar.MILLISECOND)));
+        assertEquals("Jetzt", prettyTime.format(addTime(5, Calendar.MILLISECOND)));
+        assertEquals("Jetzt", prettyTime.format(addTime(1, Calendar.MILLISECOND)));
+
+        // the following tests are commented out, because the formatDuration() method
+        // only returns an empty string for durations in the milliseconds
+        //assertEquals("5 Millisekunden", prettyTime.formatDuration(addTime(-5, Calendar.MILLISECOND)));
+        //assertEquals("1 Millisekunde", prettyTime.formatDuration(addTime(-1, Calendar.MILLISECOND)));
+    }
+
+    @Test
+    public void testGrammaticalCaseSeconds() {
+        assertEquals("gerade eben", prettyTime.format(addTime(-5, Calendar.SECOND)));
+        assertEquals("gerade eben", prettyTime.format(addTime(-1, Calendar.SECOND)));
+        assertEquals("Jetzt", prettyTime.format(addTime(5, Calendar.SECOND)));
+        assertEquals("Jetzt", prettyTime.format(addTime(1, Calendar.SECOND)));
+
+        // the following tests are commented out, because the formatDuration() method
+        // only returns an empty string for durations in the seconds
+        //assertEquals("5 Sekunden", prettyTime.formatDuration(addTime(-5, Calendar.SECOND)));
+        //assertEquals("1 Sekunde", prettyTime.formatDuration(addTime(-1, Calendar.SECOND)));
+    }
+
+    @Test
+    public void testGrammaticalCaseMinutes() {
+        assertEquals("vor 5 Minuten", prettyTime.format(addTime(-5, Calendar.MINUTE)));
+        assertEquals("vor 1 Minute", prettyTime.format(addTime(-1, Calendar.MINUTE)));
+        assertEquals("in 5 Minuten", prettyTime.format(addTime(5, Calendar.MINUTE)));
+        assertEquals("in 1 Minute", prettyTime.format(addTime(1, Calendar.MINUTE)));
+        assertEquals("5 Minuten", prettyTime.formatDuration(addTime(-5, Calendar.MINUTE)));
+        assertEquals("1 Minute", prettyTime.formatDuration(addTime(-1, Calendar.MINUTE)));
+    }
+
+    @Test
     public void testGrammaticalCaseHours() {
         assertEquals("vor 5 Stunden", prettyTime.format(addTime(-5, Calendar.HOUR)));
         assertEquals("vor 1 Stunde", prettyTime.format(addTime(-1, Calendar.HOUR)));
+        assertEquals("in 5 Stunden", prettyTime.format(addTime(5, Calendar.HOUR)));
+        assertEquals("in 1 Stunde", prettyTime.format(addTime(1, Calendar.HOUR)));
         assertEquals("5 Stunden", prettyTime.formatDuration(addTime(-5, Calendar.HOUR)));
         assertEquals("1 Stunde", prettyTime.formatDuration(addTime(-1, Calendar.HOUR)));
     }
@@ -38,6 +76,8 @@ public class PrettyTimeI18n_DE_Test {
     public void testGrammaticalCaseDays() {
         assertEquals("vor 5 Tagen", prettyTime.format(addTime(-5, Calendar.DAY_OF_MONTH)));
         assertEquals("vor 1 Tag", prettyTime.format(addTime(-1, Calendar.DAY_OF_MONTH)));
+        assertEquals("in 5 Tagen", prettyTime.format(addTime(5, Calendar.DAY_OF_MONTH)));
+        assertEquals("in 1 Tag", prettyTime.format(addTime(1, Calendar.DAY_OF_MONTH)));
         assertEquals("5 Tage", prettyTime.formatDuration(addTime(-5, Calendar.DAY_OF_MONTH)));
         assertEquals("1 Tag", prettyTime.formatDuration(addTime(-1, Calendar.DAY_OF_MONTH)));
     }
@@ -46,6 +86,8 @@ public class PrettyTimeI18n_DE_Test {
     public void testGrammaticalCaseMonths() {
         assertEquals("vor 5 Monaten", prettyTime.format(addTime(-5, Calendar.MONTH)));
         assertEquals("vor 1 Monat", prettyTime.format(addTime(-1, Calendar.MONTH)));
+        assertEquals("in 5 Monaten", prettyTime.format(addTime(5, Calendar.MONTH)));
+        assertEquals("in 1 Monat", prettyTime.format(addTime(1, Calendar.MONTH)));
         assertEquals("5 Monate", prettyTime.formatDuration(addTime(-5, Calendar.MONTH)));
         assertEquals("1 Monat", prettyTime.formatDuration(addTime(-1, Calendar.MONTH)));
     }
@@ -54,22 +96,28 @@ public class PrettyTimeI18n_DE_Test {
     public void testGrammaticalCaseYears() {
         assertEquals("vor 5 Jahren", prettyTime.format(addTime(-5, Calendar.YEAR)));
         assertEquals("vor 1 Jahr", prettyTime.format(addTime(-1, Calendar.YEAR)));
+        assertEquals("in 5 Jahren", prettyTime.format(addTime(5, Calendar.YEAR)));
+        assertEquals("in 1 Jahr", prettyTime.format(addTime(13, Calendar.MONTH)));
         assertEquals("5 Jahre", prettyTime.formatDuration(addTime(-5, Calendar.YEAR)));
         assertEquals("1 Jahr", prettyTime.formatDuration(addTime(-1, Calendar.YEAR)));
     }
 
     @Test
     public void testGrammaticalCaseDecades() {
-        assertEquals("vor 5 Jahrzenten", prettyTime.format(addTime(-50, Calendar.YEAR)));
-        assertEquals("vor 1 Jahrzent", prettyTime.format(addTime(-10, Calendar.YEAR)));
-        assertEquals("5 Jahrzente", prettyTime.formatDuration(addTime(-50, Calendar.YEAR)));
-        assertEquals("1 Jahrzent", prettyTime.formatDuration(addTime(-10, Calendar.YEAR)));
+        assertEquals("vor 5 Jahrzehnten", prettyTime.format(addTime(-50, Calendar.YEAR)));
+        assertEquals("vor 1 Jahrzehnt", prettyTime.format(addTime(-10, Calendar.YEAR)));
+        assertEquals("in 5 Jahrzehnten", prettyTime.format(addTime(50, Calendar.YEAR)));
+        assertEquals("in 1 Jahrzehnt", prettyTime.format(addTime(11, Calendar.YEAR)));
+        assertEquals("5 Jahrzehnte", prettyTime.formatDuration(addTime(-50, Calendar.YEAR)));
+        assertEquals("1 Jahrzehnt", prettyTime.formatDuration(addTime(-10, Calendar.YEAR)));
     }
 
     @Test
     public void testGrammaticalCaseCenturies() {
         assertEquals("vor 5 Jahrhunderten", prettyTime.format(addTime(-500, Calendar.YEAR)));
         assertEquals("vor 1 Jahrhundert", prettyTime.format(addTime(-100, Calendar.YEAR)));
+        assertEquals("in 5 Jahrhunderten", prettyTime.format(addTime(500, Calendar.YEAR)));
+        assertEquals("in 1 Jahrhundert", prettyTime.format(addTime(101, Calendar.YEAR)));
         assertEquals("5 Jahrhunderte", prettyTime.formatDuration(addTime(-500, Calendar.YEAR)));
         assertEquals("1 Jahrhundert", prettyTime.formatDuration(addTime(-100, Calendar.YEAR)));
     }
@@ -77,9 +125,11 @@ public class PrettyTimeI18n_DE_Test {
     @Test
     public void testGrammaticalCaseMillenia() {
         assertEquals("vor 5 Jahrtausenden", prettyTime.format(addTime(-5000, Calendar.YEAR)));
-        assertEquals("vor 1 Jahrtausend", prettyTime.format(addTime(-1001, Calendar.YEAR))); // why does -1000 return "10 Jahrhunderte"?
+        assertEquals("vor 1 Jahrtausend", prettyTime.format(addTime(-1001, Calendar.YEAR)));
+        assertEquals("in 5 Jahrtausenden", prettyTime.format(addTime(5000, Calendar.YEAR)));
+        assertEquals("in 1 Jahrtausend", prettyTime.format(addTime(1001, Calendar.YEAR)));
         assertEquals("5 Jahrtausende", prettyTime.formatDuration(addTime(-5000, Calendar.YEAR)));
-        assertEquals("1 Jahrtausend", prettyTime.formatDuration(addTime(-1000, Calendar.YEAR)));
+        assertEquals("1 Jahrtausend", prettyTime.formatDuration(addTime(-1001, Calendar.YEAR)));
     }
 
     // Method tearDown() is called automatically after every test method

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_DE_Test.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_DE_Test.java
@@ -1,0 +1,106 @@
+/**
+ * @author hertg
+ */
+package org.ocpsoft.prettytime;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrettyTimeI18n_DE_Test {
+
+    private Locale locale;
+    private Date base;
+    private PrettyTime prettyTime;
+
+    @Before
+    public void setUp() throws Exception {
+        locale = new Locale("de");
+        base = new Date();
+        prettyTime = new PrettyTime(base, locale);
+    }
+
+    @Test
+    public void testGrammaticalCaseHours() {
+        assertEquals("vor 5 Stunden", prettyTime.format(addTime(-5, Calendar.HOUR)));
+        assertEquals("vor 1 Stunde", prettyTime.format(addTime(-1, Calendar.HOUR)));
+        assertEquals("5 Stunden", prettyTime.formatDuration(addTime(-5, Calendar.HOUR)));
+        assertEquals("1 Stunde", prettyTime.formatDuration(addTime(-1, Calendar.HOUR)));
+    }
+
+    @Test
+    public void testGrammaticalCaseDays() {
+        assertEquals("vor 5 Tagen", prettyTime.format(addTime(-5, Calendar.DAY_OF_MONTH)));
+        assertEquals("vor 1 Tag", prettyTime.format(addTime(-1, Calendar.DAY_OF_MONTH)));
+        assertEquals("5 Tage", prettyTime.formatDuration(addTime(-5, Calendar.DAY_OF_MONTH)));
+        assertEquals("1 Tag", prettyTime.formatDuration(addTime(-1, Calendar.DAY_OF_MONTH)));
+    }
+
+    @Test
+    public void testGrammaticalCaseMonths() {
+        assertEquals("vor 5 Monaten", prettyTime.format(addTime(-5, Calendar.MONTH)));
+        assertEquals("vor 1 Monat", prettyTime.format(addTime(-1, Calendar.MONTH)));
+        assertEquals("5 Monate", prettyTime.formatDuration(addTime(-5, Calendar.MONTH)));
+        assertEquals("1 Monat", prettyTime.formatDuration(addTime(-1, Calendar.MONTH)));
+    }
+
+    @Test
+    public void testGrammaticalCaseYears() {
+        assertEquals("vor 5 Jahren", prettyTime.format(addTime(-5, Calendar.YEAR)));
+        assertEquals("vor 1 Jahr", prettyTime.format(addTime(-1, Calendar.YEAR)));
+        assertEquals("5 Jahre", prettyTime.formatDuration(addTime(-5, Calendar.YEAR)));
+        assertEquals("1 Jahr", prettyTime.formatDuration(addTime(-1, Calendar.YEAR)));
+    }
+
+    @Test
+    public void testGrammaticalCaseDecades() {
+        assertEquals("vor 5 Jahrzenten", prettyTime.format(addTime(-50, Calendar.YEAR)));
+        assertEquals("vor 1 Jahrzent", prettyTime.format(addTime(-10, Calendar.YEAR)));
+        assertEquals("5 Jahrzente", prettyTime.formatDuration(addTime(-50, Calendar.YEAR)));
+        assertEquals("1 Jahrzent", prettyTime.formatDuration(addTime(-10, Calendar.YEAR)));
+    }
+
+    @Test
+    public void testGrammaticalCaseCenturies() {
+        assertEquals("vor 5 Jahrhunderten", prettyTime.format(addTime(-500, Calendar.YEAR)));
+        assertEquals("vor 1 Jahrhundert", prettyTime.format(addTime(-100, Calendar.YEAR)));
+        assertEquals("5 Jahrhunderte", prettyTime.formatDuration(addTime(-500, Calendar.YEAR)));
+        assertEquals("1 Jahrhundert", prettyTime.formatDuration(addTime(-100, Calendar.YEAR)));
+    }
+
+    @Test
+    public void testGrammaticalCaseMillenia() {
+        assertEquals("vor 5 Jahrtausenden", prettyTime.format(addTime(-5000, Calendar.YEAR)));
+        assertEquals("vor 1 Jahrtausend", prettyTime.format(addTime(-1001, Calendar.YEAR))); // why does -1000 return "10 Jahrhunderte"?
+        assertEquals("5 Jahrtausende", prettyTime.formatDuration(addTime(-5000, Calendar.YEAR)));
+        assertEquals("1 Jahrtausend", prettyTime.formatDuration(addTime(-1000, Calendar.YEAR)));
+    }
+
+    // Method tearDown() is called automatically after every test method
+    @After
+    public void tearDown() throws Exception {
+        Locale.setDefault(locale);
+    }
+
+    /**
+     * Helper method to simplify unit tests
+     * and prevent code duplicates.
+     *
+     * @param amount Amount of time to add
+     * @param field Calendar field (ie. {@link Calendar#HOUR}, {@link Calendar#YEAR})
+     * @return Date with the added quantity of time
+     */
+    private Date addTime(int amount, int field) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(base);
+        calendar.add(field, amount);
+        return calendar.getTime();
+    }
+
+}


### PR DESCRIPTION
This fixes the issues mentioned in the original post at #175. 

However, the issue still persists when calling `formatDuration(Duration)` with a precise Duration that contains multiple units inside the same string. 

E.g. The following test would still fail:

```java
assertEquals("in 2 Monaten 4 Stunden 2 Minuten",
    prettyTime.format(prettyTime.calculatePreciseDuration(addTime(61, Calendar.DAY_OF_YEAR))));
```

```
Expected :in 2 Monaten 4 Stunden 2 Minuten
Actual   :in 2 Monate 4 Stunden 2 Minuten
```

> I don't really understand why this even results in "in 2 months 4 hours 2 minutes", but I'm probably missing something.

That's because with the current API and without the necessary context information, this can't be solved without doing **really** dirty workarounds.

All the tests I've added run successfully. Funny enough, some of the others tests fail. But that was already the case before I applied my changes. Might be related to my system (?), would be good if anybody could take a look at that.