### PR TITLE
Add java.time support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ProGuard rules are automatically configured for you if you use the R8 shrinker (
 
 Be sure to check maven central for the latest version: https://repo1.maven.org/maven2/org/ocpsoft/prettytime/prettytime/
 
+**Note**: To use prettytime in projects with a `minSdkVersion` below 26, [API desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) is required.
+
 DEVELOPMENT
 ===========
 force-release: mvn release:prepare release:perform -DskipTests=true -DdevelopmentVersion=4.0.2-SNAPSHOT -DreleaseVersion=4.0.1.Final -Dtag=4.0.1.Final -Darguments="-DskipTests=true -Dmaven.test.skip=true"

--- a/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
@@ -15,6 +15,12 @@
  */
 package org.ocpsoft.prettytime;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -65,7 +71,7 @@ public class PrettyTime
 {
    private volatile Date reference;
    private volatile Locale locale = Locale.getDefault();
-   private volatile Map<TimeUnit, TimeFormat> units = new LinkedHashMap<TimeUnit, TimeFormat>();
+   private volatile Map<TimeUnit, TimeFormat> units = new LinkedHashMap<>();
    private volatile List<TimeUnit> cachedUnits;
    private String overrideResourceBundle;
 
@@ -186,8 +192,8 @@ public class PrettyTime
    /**
     * Calculate the approximate {@link Duration} between the reference {@link Date} and given {@link Date}. If the given
     * {@link Date} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
-    * <p>
-    * See {@code PrettyTime#getReference()}.
+    *
+    * @see #getReference()
     */
    public Duration approximateDuration(Date then)
    {
@@ -200,6 +206,18 @@ public class PrettyTime
 
       long difference = then.getTime() - ref.getTime();
       return calculateDuration(difference);
+   }
+
+   /**
+    * Calculate the approximate {@link Duration} between the reference {@link Date} and given {@link Instant}.
+    * If the given {@link Instant} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be
+    * used instead.
+    *
+    * @see #getReference()
+    */
+   public Duration approximateDuration(Instant then)
+   {
+      return approximateDuration(then != null ? Date.from(then) : null);
    }
 
    /**
@@ -226,14 +244,14 @@ public class PrettyTime
       if (null == reference)
          reference = now();
 
-      List<Duration> result = new ArrayList<Duration>();
+      List<Duration> result = new ArrayList<>();
       long difference = then.getTime() - reference.getTime();
       Duration duration = calculateDuration(difference);
       result.add(duration);
       while (0 != duration.getDelta())
       {
          duration = calculateDuration(duration.getDelta());
-         if (result.size() > 0)
+         if (!result.isEmpty())
          {
             Duration last = result.get(result.size() - 1);
             if (last.getUnit().equals(duration.getUnit()))
@@ -246,6 +264,26 @@ public class PrettyTime
             result.add(duration);
       }
       return result;
+   }
+
+   /**
+    * Calculate to the precision of the smallest provided {@link TimeUnit}, the exact {@link Duration} represented by
+    * the difference between the reference {@link Date} and the given {@link Instant}. If the given {@link Instant} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    * <b>Note</b>: Precision may be lost if no supplied {@link TimeUnit} is granular enough to represent the remainder
+    * of time (in milliseconds).
+    *
+    * @param then The {@link Instant} to be compared against the reference timestamp, or <i>now</i> if no reference
+    *           timestamp was provided
+    * @return A sorted {@link List} of {@link Duration} objects, from largest to smallest. Each element in the list
+    *         represents the approximate duration (number of times) that {@link TimeUnit} to fit into the previous
+    *         element's delta. The first element is the largest {@link TimeUnit} to fit within the total difference
+    *         between compared dates.
+    */
+   public List<Duration> calculatePreciseDuration(Instant then)
+   {
+      return calculatePreciseDuration(then != null ? Date.from(then) : null);
    }
 
    /**
@@ -331,6 +369,97 @@ public class PrettyTime
    }
 
    /**
+    * Format the given {@link Instant} object. If the given {@link Instant} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link Instant} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final Instant then)
+   {
+      return format(approximateDuration(then));
+   }
+
+   /**
+    * Format the given {@link ZonedDateTime} object. If the given {@link ZonedDateTime} is <code>null</code>, the
+    * current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link ZonedDateTime} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final ZonedDateTime then)
+   {
+      return format(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link OffsetDateTime} object. If the given {@link OffsetDateTime} is <code>null</code>, the
+    * current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link OffsetDateTime} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final OffsetDateTime then)
+   {
+      return format(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} object using the given {@link ZoneId}. If the given {@link LocalDateTime}
+    * is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @param zoneId the {@link ZoneId} to be used, not null
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final LocalDateTime then, final ZoneId zoneId)
+   {
+      return format(then != null ? then.atZone(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} object using the system default {@link ZoneId}. If the given
+    * {@link LocalDateTime} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used
+    * instead.
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final LocalDateTime then)
+   {
+      return format(then, ZoneId.systemDefault());
+   }
+
+   /**
+    * Format the given {@link LocalDate} object using the given {@link ZoneId}. If the given {@link LocalDate} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @param zoneId the {@link ZoneId} to be used, not null
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final LocalDate then, final ZoneId zoneId)
+   {
+      return format(then != null ? then.atStartOfDay(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDate} object using the system default {@link ZoneId}. If the given {@link LocalDate}
+    * is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String format(final LocalDate then)
+   {
+      return format(then != null ? then.atStartOfDay() : null);
+   }
+
+   /**
     * Format the given {@link Date} object. Rounding rules are ignored. If the given {@link Date} is <code>null</code>,
     * the current value of {@link System#currentTimeMillis()} will be used instead.
     * 
@@ -409,6 +538,100 @@ public class PrettyTime
    }
 
    /**
+    * Format the given {@link Instant} object. Rounding rules are ignored. If the given {@link Instant} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link Instant} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final Instant then)
+   {
+      return formatUnrounded(approximateDuration(then));
+   }
+
+   /**
+    * Format the given {@link ZonedDateTime} object. Rounding rules are ignored. If the given {@link ZonedDateTime} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link ZonedDateTime} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final ZonedDateTime then)
+   {
+      return formatUnrounded(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link OffsetDateTime} object. Rounding rules are ignored. If the given {@link OffsetDateTime} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * @param then the {@link OffsetDateTime} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final OffsetDateTime then)
+   {
+      return formatUnrounded(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} object using the given {@link ZoneId}. Rounding rules are ignored. If the
+    * given {@link LocalDateTime} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be
+    * used instead.
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @param zoneId the {@link ZoneId} to be used, not null
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final LocalDateTime then, final ZoneId zoneId)
+   {
+      return formatUnrounded(then != null ? then.atZone(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} object using the system default {@link ZoneId}. Rounding rules are ignored.
+    * If the given {@link LocalDateTime} is <code>null</code>, the current value of {@link System#currentTimeMillis()}
+    * will be used instead.
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final LocalDateTime then)
+   {
+      return formatUnrounded(then, ZoneId.systemDefault());
+   }
+
+   /**
+    * Format the given {@link LocalDate} object using the given {@link ZoneId}. Rounding rules are ignored. If the
+    * given {@link LocalDate} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be
+    * used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @param zoneId the {@link ZoneId} to be used, not null
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final LocalDate then, final ZoneId zoneId)
+   {
+      return formatUnrounded(then != null ? then.atStartOfDay(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDate} object using the system default {@link ZoneId}. Rounding rules are ignored.
+    * If the given {@link LocalDate} is <code>null</code>, the current value of {@link System#currentTimeMillis()}
+    * will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @return A formatted string representing {@code then}
+    */
+   public String formatUnrounded(final LocalDate then)
+   {
+      return formatUnrounded(then != null ? then.atStartOfDay() : null);
+   }
+
+   /**
     * Format the given {@link Date} and return a non-relative (not decorated with past or future tense) {@link String}
     * for the approximate duration of its difference between the reference {@link Date}. If the given {@link Date} is
     * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
@@ -466,7 +689,7 @@ public class PrettyTime
     * {@link Duration} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used
     * instead.
     * 
-    * @param duration the duration to be formatted
+    * @param durations the durations to be formatted
     * @return A formatted string of the given {@link Duration}
     */
    public String formatDuration(final List<Duration> durations)
@@ -492,6 +715,112 @@ public class PrettyTime
       }
 
       return result.toString();
+   }
+
+   /**
+    * Format the given {@link Instant} and return a non-relative (not decorated with past or future tense) {@link String}
+    * for the approximate duration of its difference between the reference {@link Date}. If the given {@link Instant} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link Instant} to be formatted
+    * @return A formatted string of the given {@link Instant}
+    */
+   public String formatDuration(final Instant then)
+   {
+      return formatDuration(approximateDuration(then));
+   }
+
+   /**
+    * Format the given {@link Instant} and return a non-relative (not decorated with past or future tense) {@link String}
+    * for the approximate duration of its difference between the reference {@link Date}. If the given {@link Instant} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link ZonedDateTime} to be formatted
+    * @return A formatted string of the given {@link Instant}
+    */
+   public String formatDuration(final ZonedDateTime then)
+   {
+      return formatDuration(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link Instant} and return a non-relative (not decorated with past or future tense) {@link String}
+    * for the approximate duration of its difference between the reference {@link Date}. If the given {@link Instant} is
+    * <code>null</code>, the current value of {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link OffsetDateTime} to be formatted
+    * @return A formatted string of the given {@link Instant}
+    */
+   public String formatDuration(final OffsetDateTime then)
+   {
+      return formatDuration(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} using the given {@link ZoneId} and return a non-relative (not decorated
+    * with past or future tense) {@link String} for the approximate duration of its difference between the reference
+    * {@link Date}. If the given {@link Instant} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @param zoneId the {@link ZoneId} to be used, not null
+    * @return A formatted string of the given {@link LocalDateTime}
+    */
+   public String formatDuration(final LocalDateTime then, final ZoneId zoneId)
+   {
+      return formatDuration(then != null ? then.atZone(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} using the system default {@link ZoneId} and return a non-relative (not
+    * decorated with past or future tense) {@link String} for the approximate duration of its difference between the
+    * reference {@link Date}. If the given {@link Instant} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @return A formatted string of the given {@link LocalDateTime}
+    */
+   public String formatDuration(final LocalDateTime then)
+   {
+      return formatDuration(then, ZoneId.systemDefault());
+   }
+
+   /**
+    * Format the given {@link LocalDate} using the given {@link ZoneId} and return a non-relative (not decorated with
+    * past or future tense) {@link String} for the approximate duration of its difference between the reference
+    * {@link Date}. If the given {@link LocalDate} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @param zoneId the {@link ZoneId} to be used, not null
+    * @return A formatted string of the given {@link LocalDate}
+    */
+   public String formatDuration(final LocalDate then, final ZoneId zoneId)
+   {
+      return formatDuration(then != null ? then.atStartOfDay(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDate} using the system default {@link ZoneId} and return a non-relative (not
+    * decorated with past or future tense) {@link String} for the approximate duration of its difference between the
+    * reference {@link Date}. If the given {@link LocalDate} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @return A formatted string of the given {@link LocalDate}
+    */
+   public String formatDuration(final LocalDate then)
+   {
+      return formatDuration(then != null ? then.atStartOfDay() : null);
    }
 
    /**
@@ -553,7 +882,7 @@ public class PrettyTime
     * are ignored. If the given {@link Duration} is <code>null</code>, the current value of
     * {@link System#currentTimeMillis()} will be used instead.
     * 
-    * @param duration the duration to be formatted
+    * @param durations the durations to be formatted
     * @return A formatted string of the given {@link Duration}
     */
    public String formatDurationUnrounded(final List<Duration> durations)
@@ -574,6 +903,113 @@ public class PrettyTime
       }
 
       return result.toString();
+   }
+
+   /**
+    * Format the given {@link Instant} and return a non-relative (not decorated with past or future tense) {@link String}
+    * for the approximate duration of its difference between the reference {@link Date}. Rounding rules are ignored. If
+    * the given {@link Instant} is <code>null</code>, the current value of {@link System#currentTimeMillis()} will be
+    * used instead.
+    * <p>
+    *
+    * @param then the {@link Instant} to be formatted
+    * @return A formatted string of the given {@link Instant}
+    */
+   public String formatDurationUnrounded(final Instant then)
+   {
+      return formatDurationUnrounded(approximateDuration(then));
+   }
+
+   /**
+    * Format the given {@link ZonedDateTime} and return a non-relative (not decorated with past or future tense)
+    * {@link String} for the approximate duration of its difference between the reference {@link Date}. Rounding rules
+    * are ignored. If the given {@link Date} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link ZonedDateTime} to be formatted
+    * @return A formatted string of the given {@link ZonedDateTime}
+    */
+   public String formatDurationUnrounded(final ZonedDateTime then)
+   {
+      return formatDurationUnrounded(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link OffsetDateTime} and return a non-relative (not decorated with past or future tense)
+    * {@link String} for the approximate duration of its difference between the reference {@link Date}. Rounding rules
+    * are ignored. If the given {@link OffsetDateTime} is <code>null</code>, the current value of
+    * {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link OffsetDateTime} to be formatted
+    * @return A formatted string of the given {@link OffsetDateTime}
+    */
+   public String formatDurationUnrounded(final OffsetDateTime then)
+   {
+      return formatDurationUnrounded(then != null ? then.toInstant() : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} using the given {@link ZoneId} and return a non-relative (not decorated
+    * with past or future tense) {@link String} for the approximate duration of its difference between the reference
+    * {@link Date}. Rounding rules are ignored. If the given {@link LocalDateTime} is <code>null</code>, the current
+    * value of {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @return A formatted string of the given {@link LocalDateTime}
+    */
+   public String formatDurationUnrounded(final LocalDateTime then, final ZoneId zoneId)
+   {
+      return formatDurationUnrounded(then != null ? then.atZone(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDateTime} using the system default {@link ZoneId} and return a non-relative (not
+    * decorated with past or future tense) {@link String} for the approximate duration of its difference between the
+    * reference {@link Date}. Rounding rules are ignored. If the given {@link LocalDateTime} is <code>null</code>, the
+    * current value of {@link System#currentTimeMillis()} will be used instead.
+    * <p>
+    *
+    * @param then the {@link LocalDateTime} to be formatted
+    * @return A formatted string of the given {@link LocalDateTime}
+    */
+   public String formatDurationUnrounded(final LocalDateTime then)
+   {
+      return formatDurationUnrounded(then, ZoneId.systemDefault());
+   }
+
+   /**
+    * Format the given {@link LocalDate} using the given {@link ZoneId} and return a non-relative (not decorated with
+    * past or future tense) {@link String} for the approximate duration of its difference between the reference
+    * {@link Date}. Rounding rules are ignored. If the given {@link LocalDate} is <code>null</code>, the current value
+    * of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @return A formatted string of the given {@link LocalDate}
+    */
+   public String formatDurationUnrounded(final LocalDate then, final ZoneId zoneId)
+   {
+      return formatDurationUnrounded(then != null ? then.atStartOfDay(zoneId) : null);
+   }
+
+   /**
+    * Format the given {@link LocalDate} using the system default {@link ZoneId} and return a non-relative (not decorated
+    * with past or future tense) {@link String} for the approximate duration of its difference between the reference
+    * {@link Date}. Rounding rules are ignored. If the given {@link LocalDate} is <code>null</code>, the current value
+    * of {@link System#currentTimeMillis()} will be used instead.
+    *
+    * <p>This assumes that the time of the given date is midnight.</p>
+    *
+    * @param then the {@link LocalDate} to be formatted
+    * @return A formatted string of the given {@link LocalDate}
+    */
+   public String formatDurationUnrounded(final LocalDate then)
+   {
+      return formatDurationUnrounded(then != null ? then.atStartOfDay() : null);
    }
 
    /**

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeAPIManipulationTest.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeAPIManipulationTest.java
@@ -18,6 +18,11 @@ package org.ocpsoft.prettytime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -33,13 +38,13 @@ public class PrettyTimeAPIManipulationTest
    @Test
    public void testApiMisuse1() throws Exception
    {
-      Assert.assertEquals(t.approximateDuration(new Date()), t.approximateDuration(null));
+      Assert.assertEquals(t.approximateDuration(new Date()), t.approximateDuration((Date) null));
    }
 
    @Test
    public void testApiMisuse2() throws Exception
    {
-      Assert.assertEquals(t.calculatePreciseDuration(new Date()), t.calculatePreciseDuration(null));
+      Assert.assertEquals(t.calculatePreciseDuration(new Date()), t.calculatePreciseDuration((Date) null));
    }
 
    @Test
@@ -73,6 +78,54 @@ public class PrettyTimeAPIManipulationTest
    }
 
    @Test
+   public void testApiMisuse4_4() throws Exception
+   {
+      Assert.assertEquals(t.format(new Date()), t.format((Instant) null));
+   }
+
+   @Test
+   public void testApiMisuse4_5() throws Exception
+   {
+      Assert.assertEquals(t.format(new Date()), t.format((ZonedDateTime) null));
+   }
+
+   @Test
+   public void testApiMisuse4_6() throws Exception
+   {
+      Assert.assertEquals(t.format(new Date()), t.format((OffsetDateTime) null));
+   }
+
+   @Test
+   public void testApiMisuse4_7_1() throws Exception
+   {
+      Assert.assertEquals(t.format(new Date()), t.format((LocalDateTime) null, null));
+   }
+
+   @Test(expected = NullPointerException.class)
+   public void testApiMisuse4_7_2()
+   {
+      t.format(LocalDateTime.now(), null);
+   }
+
+   @Test
+   public void testApiMisuse4_8()
+   {
+      Assert.assertEquals(t.format(new Date()), t.format((LocalDateTime) null));
+   }
+
+   @Test
+   public void testApiMisuse4_9_1() throws Exception
+   {
+      Assert.assertEquals(t.format(new Date()), t.format((LocalDate) null, null));
+   }
+
+   @Test(expected = NullPointerException.class)
+   public void testApiMisuse4_9_2()
+   {
+      t.format(LocalDate.now(), null);
+   }
+
+   @Test
    public void testApiMisuse5() throws Exception
    {
       Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((Date) null));
@@ -94,6 +147,54 @@ public class PrettyTimeAPIManipulationTest
    public void testApiMisuse5_3() throws Exception
    {
       Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((List<Duration>) null));
+   }
+
+   @Test
+   public void testApiMisuse5_4() throws Exception
+   {
+      Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((Instant) null));
+   }
+
+   @Test
+   public void testApiMisuse5_5() throws Exception
+   {
+      Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((ZonedDateTime) null));
+   }
+
+   @Test
+   public void testApiMisuse5_6() throws Exception
+   {
+      Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((OffsetDateTime) null));
+   }
+
+   @Test
+   public void testApiMisuse5_7_1() throws Exception
+   {
+      Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((LocalDateTime) null, null));
+   }
+
+   @Test(expected = NullPointerException.class)
+   public void testApiMisuse5_7_2()
+   {
+      t.formatUnrounded(LocalDateTime.now(), null);
+   }
+
+   @Test
+   public void testApiMisuse5_8()
+   {
+      Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((LocalDateTime) null));
+   }
+
+   @Test
+   public void testApiMisuse5_9_1() throws Exception
+   {
+      Assert.assertEquals(t.formatUnrounded(new Date()), t.formatUnrounded((LocalDate) null, null));
+   }
+
+   @Test(expected = NullPointerException.class)
+   public void testApiMisuse5_9_2()
+   {
+      t.formatUnrounded(LocalDate.now(), null);
    }
 
    @Test

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeTest.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeTest.java
@@ -16,6 +16,8 @@
 package org.ocpsoft.prettytime;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -76,6 +78,12 @@ public class PrettyTimeTest
       Assert.assertEquals("2 hours 2 minutes ago", t.format(preciseDuration));
       Assert.assertEquals("2 hours 2 minutes", t.formatDuration(preciseDuration));
       Assert.assertEquals("moments from now", t.format(t.calculatePreciseDuration(new Date())));
+
+      preciseDuration = t.calculatePreciseDuration(Instant.now().minus(2, ChronoUnit.HOURS)
+              .minus(2, ChronoUnit.MINUTES));
+      Assert.assertEquals("2 hours 2 minutes ago", t.format(preciseDuration));
+      Assert.assertEquals("2 hours 2 minutes", t.formatDuration(preciseDuration));
+      Assert.assertEquals("moments from now", t.format(t.calculatePreciseDuration(Instant.now())));
    }
 
    @Test
@@ -367,7 +375,11 @@ public class PrettyTimeTest
       Date tenMinAgo = new Date(System.currentTimeMillis() - tenMinMillis);
       PrettyTime t = new PrettyTime();
       String result = t.formatDuration(tenMinAgo);
-      Assert.assertTrue(result.equals("10 minutes"));
+      Assert.assertEquals("10 minutes", result);
+
+      Instant tenMinutesAgo = Instant.now().minus(10, ChronoUnit.MINUTES);
+      result = t.formatDuration(tenMinutesAgo);
+      Assert.assertEquals("10 minutes", result);
    }
 
    @Test
@@ -377,7 +389,11 @@ public class PrettyTimeTest
       Date tenMinAgo = new Date(System.currentTimeMillis() - tenMinMillis);
       PrettyTime t = new PrettyTime();
       String result = t.formatDuration(tenMinAgo);
-      Assert.assertTrue(result.equals("11 minutes"));
+      Assert.assertEquals("11 minutes", result);
+
+      Instant tenMinutesAgo = Instant.now().minus(10, ChronoUnit.MINUTES).minusSeconds(40);
+      result = t.formatDuration(tenMinutesAgo);
+      Assert.assertEquals("11 minutes", result);
    }
 
    @Test
@@ -387,7 +403,11 @@ public class PrettyTimeTest
       Date tenMinAgo = new Date(System.currentTimeMillis() - tenMinMillis);
       PrettyTime t = new PrettyTime();
       String result = t.formatDurationUnrounded(tenMinAgo);
-      Assert.assertTrue(result.equals("10 minutes"));
+      Assert.assertEquals("10 minutes", result);
+
+      Instant tenMinutesAgo = Instant.now().minus(10, ChronoUnit.MINUTES).minusSeconds(40);
+      result = t.formatDurationUnrounded(tenMinutesAgo);
+      Assert.assertEquals("10 minutes", result);
    }
 
    @Test

--- a/core/src/test/java/org/ocpsoft/prettytime/SimpleTimeFormatTest.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/SimpleTimeFormatTest.java
@@ -17,6 +17,7 @@ package org.ocpsoft.prettytime;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.*;
 import java.util.Date;
 import java.util.Locale;
 
@@ -49,6 +50,11 @@ public class SimpleTimeFormatTest
 
       assertEquals("4 hours ago", t.format(duration));
       assertEquals("3 hours ago", t.formatUnrounded(duration));
+
+      duration = t.approximateDuration(Instant.ofEpochMilli(0));
+
+      assertEquals("4 hours ago", t.format(duration));
+      assertEquals("3 hours ago", t.formatUnrounded(duration));
    }
 
    @Test
@@ -61,6 +67,12 @@ public class SimpleTimeFormatTest
       assertEquals("some time from now", format.decorate(duration, "some time"));
 
       duration = t.approximateDuration(new Date(System.currentTimeMillis() - 10000));
+      assertEquals("some time ago", format.decorate(duration, "some time"));
+
+      duration = t.approximateDuration(Instant.now().plusSeconds(1));
+      assertEquals("some time from now", format.decorate(duration, "some time"));
+
+      duration = t.approximateDuration(Instant.now().minusSeconds(10));
       assertEquals("some time ago", format.decorate(duration, "some time"));
    }
 


### PR DESCRIPTION
Add methods to `PrettyTime` that accept the types defined in `java.time`.

This fixes https://github.com/ocpsoft/prettytime/issues/109.