### PR TITLE
Mutable methods are now protected

### DIFF
--- a/jstl/src/main/java/org/ocpsoft/prettytime/jstl/PrettyTimeTag.java
+++ b/jstl/src/main/java/org/ocpsoft/prettytime/jstl/PrettyTimeTag.java
@@ -1,24 +1,34 @@
 package org.ocpsoft.prettytime.jstl;
 
-import org.apache.taglibs.standard.tag.common.fmt.SetLocaleSupport;
-import org.ocpsoft.prettytime.PrettyTime;
+import java.io.IOException;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.SimpleTagSupport;
-import java.io.IOException;
-import java.util.Date;
-import java.util.Locale;
+
+import org.apache.taglibs.standard.tag.common.fmt.SetLocaleSupport;
+import org.ocpsoft.prettytime.PrettyTime;
 
 /**
  * Custom tag to pretty print {@link java.util.Date} objects using <a href="http://ocpsoft.org/prettytime/">prettytime</a>.
  */
 public class PrettyTimeTag extends SimpleTagSupport {
 
-    /**
-     * The pretty time object.
-     */
-    private PrettyTime prettyTime;
+    private static final int MAX_CACHE_SIZE = 20;
+
+    // Cache PrettyTime per locale. LRU cache to prevent memory leak.
+    private static final Map<Locale, PrettyTime> PRETTY_TIME_LOCALE_MAP = new LinkedHashMap<Locale, PrettyTime>(MAX_CACHE_SIZE + 1, 1.1F, true) {
+        private static final long serialVersionUID = 5093634937930600141L;
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Locale, PrettyTime> eldest) {
+            return size() > MAX_CACHE_SIZE;
+        }
+    };
 
     /**
      * The date to pretty print.
@@ -31,23 +41,25 @@ public class PrettyTimeTag extends SimpleTagSupport {
     private String locale;
 
     public PrettyTimeTag() {
-        prettyTime = new PrettyTime();
     }
 
     @Override
     public void doTag() throws JspException, IOException {
+        final Locale thisLocale;
         if (locale != null) {
-            Locale locale = SetLocaleSupport.parseLocale(this.locale);
-            prettyTime.setLocale(locale);
+            thisLocale = SetLocaleSupport.parseLocale(this.locale);
+        } else {
+            thisLocale = Locale.getDefault();
         }
 
+        PrettyTime prettyTime = PRETTY_TIME_LOCALE_MAP.computeIfAbsent(thisLocale, PrettyTime::new);
         JspWriter out = getJspContext().getOut();
         out.print(prettyTime.format(date));
     }
 
     /*
-    * setters for tag attributes
-    */
+     * setters for tag attributes
+     */
 
     public void setDate(Date date) {
         this.date = date;


### PR DESCRIPTION
In order to preserve the simplicity of the API and keep tests easy to write, I made the methods that change the internal state in PrettyTime package-protected.

This will require a major version bump. 

Fixes #211