### PR TITLE
Added support for plural forms in Polish language

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_pl.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_pl.java
@@ -15,102 +15,96 @@
  */
 package org.ocpsoft.prettytime.i18n;
 
+import org.ocpsoft.prettytime.Duration;
+import org.ocpsoft.prettytime.TimeFormat;
+import org.ocpsoft.prettytime.TimeUnit;
+import org.ocpsoft.prettytime.impl.TimeFormatProvider;
+import org.ocpsoft.prettytime.units.*;
+
 import java.util.ListResourceBundle;
 
-public class Resources_pl extends ListResourceBundle
+public class Resources_pl extends ListResourceBundle implements TimeFormatProvider
 {
-   private static final Object[][] OBJECTS = new Object[][] {
-            { "CenturyPattern", "%n %u" },
-            { "CenturyFuturePrefix", "za " },
-            { "CenturyFutureSuffix", "" },
-            { "CenturyPastPrefix", "" },
-            { "CenturyPastSuffix", " temu" },
-            { "CenturySingularName", "wiek" },
-            { "CenturyPluralName", "wiek(i/ów)" },
-            { "DayPattern", "%n %u" },
-            { "DayFuturePrefix", "za " },
-            { "DayFutureSuffix", "" },
-            { "DayPastPrefix", "" },
-            { "DayPastSuffix", " temu" },
-            { "DaySingularName", "dzień" },
-            { "DayPluralName", "dni" },
-            { "DecadePattern", "%n %u" },
-            { "DecadeFuturePrefix", "za " },
-            { "DecadeFutureSuffix", "" },
-            { "DecadePastPrefix", "" },
-            { "DecadePastSuffix", " temu" },
-            { "DecadeSingularName", "dekadę" },
-            { "DecadePluralName", "dekad" },
-            { "HourPattern", "%n %u" },
-            { "HourFuturePrefix", "za " },
-            { "HourFutureSuffix", "" },
-            { "HourPastPrefix", "" },
-            { "HourPastSuffix", " temu" },
-            { "HourSingularName", "godz." },
-            { "HourPluralName", "godz." },
-            { "JustNowPattern", "%u" },
-            { "JustNowFuturePrefix", "" },
-            { "JustNowFutureSuffix", "za chwilę" },
-            { "JustNowPastPrefix", "przed chwilą" },
-            { "JustNowPastSuffix", "" },
-            { "JustNowSingularName", "" },
-            { "JustNowPluralName", "" },
-            { "MillenniumPattern", "%n %u" },
-            { "MillenniumFuturePrefix", "za " },
-            { "MillenniumFutureSuffix", "" },
-            { "MillenniumPastPrefix", "" },
-            { "MillenniumPastSuffix", " temu" },
-            { "MillenniumSingularName", "milenium" },
-            { "MillenniumPluralName", "milenia" },
-            { "MillisecondPattern", "%n %u" },
-            { "MillisecondFuturePrefix", "za " },
-            { "MillisecondFutureSuffix", "" },
-            { "MillisecondPastPrefix", "" },
-            { "MillisecondPastSuffix", " temu" },
-            { "MillisecondSingularName", "milisek." },
-            { "MillisecondPluralName", "milisek." },
-            { "MinutePattern", "%n %u" },
-            { "MinuteFuturePrefix", "za " },
-            { "MinuteFutureSuffix", "" },
-            { "MinutePastPrefix", "" },
-            { "MinutePastSuffix", " temu" },
-            { "MinuteSingularName", "min" },
-            { "MinutePluralName", "min" },
-            { "MonthPattern", "%n %u" },
-            { "MonthFuturePrefix", "za " },
-            { "MonthFutureSuffix", "" },
-            { "MonthPastPrefix", "" },
-            { "MonthPastSuffix", " temu" },
-            { "MonthSingularName", "mies." },
-            { "MonthPluralName", "mies." },
-            { "SecondPattern", "%n %u" },
-            { "SecondFuturePrefix", "za " },
-            { "SecondFutureSuffix", "" },
-            { "SecondPastPrefix", "" },
-            { "SecondPastSuffix", " temu" },
-            { "SecondSingularName", "sek." },
-            { "SecondPluralName", "sek." },
-            { "WeekPattern", "%n %u" },
-            { "WeekFuturePrefix", "za " },
-            { "WeekFutureSuffix", "" },
-            { "WeekPastPrefix", "" },
-            { "WeekPastSuffix", " temu" },
-            { "WeekSingularName", "tydzień" },
-            { "WeekPluralName", "tygodni(e)" },
-            { "YearPattern", "%n %u" },
-            { "YearFuturePrefix", "za " },
-            { "YearFutureSuffix", "" },
-            { "YearPastPrefix", "" },
-            { "YearPastSuffix", " temu" },
-            { "YearSingularName", "rok" },
-            { "YearPluralName", "lat(a)" },
-            { "AbstractTimeUnitPattern", "" },
-            { "AbstractTimeUnitFuturePrefix", "" },
-            { "AbstractTimeUnitFutureSuffix", "" },
-            { "AbstractTimeUnitPastPrefix", "" },
-            { "AbstractTimeUnitPastSuffix", "" },
-            { "AbstractTimeUnitSingularName", "" },
-            { "AbstractTimeUnitPluralName", "" } };
+   private static final Object[][] OBJECTS = new Object[0][0];
+
+   private static final int tolerance = 50;
+
+   // see http://translate.sourceforge.net/wiki/l10n/pluralforms
+   private static final int polishPluralForms = 3;
+
+   private static class TimeFormatAided implements TimeFormat
+   {
+      private final String[] plurals;
+
+      public TimeFormatAided(String... plurals)
+      {
+         if (plurals.length != polishPluralForms) {
+            throw new IllegalArgumentException("Wrong plural forms number for Polish language!");
+         }
+         this.plurals = plurals;
+      }
+
+      @Override
+      public String format(Duration duration)
+      {
+         long quantity = duration.getQuantityRounded(tolerance);
+         return String.valueOf(quantity);
+      }
+
+      @Override
+      public String formatUnrounded(Duration duration)
+      {
+         long quantity = Math.abs(duration.getQuantity());
+         return String.valueOf(quantity);
+      }
+
+      @Override
+      public String decorate(Duration duration, String time)
+      {
+         return performDecoration(
+                 duration.isInPast(),
+                 duration.isInFuture(),
+                 duration.getQuantityRounded(tolerance),
+                 time);
+      }
+
+      @Override
+      public String decorateUnrounded(Duration duration, String time)
+      {
+         return performDecoration(
+                 duration.isInPast(),
+                 duration.isInFuture(),
+                 Math.abs(duration.getQuantity()),
+                 time);
+      }
+
+      private String performDecoration(boolean past, boolean future, long n, String time)
+      {
+         // a bit cryptic, yet well-tested
+         // consider http://translate.sourceforge.net/wiki/l10n/pluralforms
+         int pluralIdx = (n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
+         if (pluralIdx > polishPluralForms) {
+            // impossible happening
+            throw new IllegalStateException("Wrong plural index was calculated somehow for Polish language");
+         }
+
+         StringBuilder result = new StringBuilder();
+
+         if (future) {
+            result.append("za ");
+         }
+
+         result.append(time);
+         result.append(' ');
+         result.append(plurals[pluralIdx]);
+
+         if (past) {
+            result.append(" temu");
+         }
+
+         return result.toString();
+      }
+   }
 
    @Override
    public Object[][] getContents()
@@ -118,4 +112,80 @@ public class Resources_pl extends ListResourceBundle
       return OBJECTS;
    }
 
+   @Override
+   public TimeFormat getFormatFor(TimeUnit t)
+   {
+      if (t instanceof JustNow) {
+         return new TimeFormat() {
+            @Override
+            public String format(Duration duration)
+            {
+               return performFormat(duration);
+            }
+
+            @Override
+            public String formatUnrounded(Duration duration)
+            {
+               return performFormat(duration);
+            }
+
+            private String performFormat(Duration duration)
+            {
+               if (duration.isInFuture()) {
+                  return "za chwilę";
+               }
+               if (duration.isInPast()) {
+                  return "przed chwilą";
+               }
+               return null;
+            }
+
+            @Override
+            public String decorate(Duration duration, String time)
+            {
+               return time;
+            }
+
+            @Override
+            public String decorateUnrounded(Duration duration, String time)
+            {
+               return time;
+            }
+         };
+      }
+      else if (t instanceof Century) {
+         return new TimeFormatAided("wiek", "wieki", "wieków");
+      }
+      else if (t instanceof Day) {
+         return new TimeFormatAided("dzień", "dni", "dni");
+      }
+      else if (t instanceof Decade) {
+         return new TimeFormatAided("dekadę", "dekady", "dekad");
+      }
+      else if (t instanceof Hour) {
+         return new TimeFormatAided("godzinę", "godziny", "godzin");
+      }
+      else if (t instanceof Millennium) {
+         return new TimeFormatAided("milenium", "milenia", "mileniów");
+      }
+      else if (t instanceof Millisecond) {
+         return new TimeFormatAided("milisekundę", "milisekundy", "milisekund");
+      }
+      else if (t instanceof Minute) {
+         return new TimeFormatAided("minutę", "minuty", "minut");
+      }
+      else if (t instanceof Month) {
+         return new TimeFormatAided("miesiąc", "miesiące", "miesięcy");
+      }
+      else if (t instanceof Second) {
+         return new TimeFormatAided("sekundę", "sekundy", "sekund");
+      }
+      else if (t instanceof Week) {
+         return new TimeFormatAided("tydzień", "tygodnie", "tygodni");
+      }
+      else if (t instanceof Year) {
+         return new TimeFormatAided("rok", "lata", "lat");
+      }
+      return null; // error
+   }
 }

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_PL_Test.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_PL_Test.java
@@ -1,0 +1,328 @@
+package org.ocpsoft.prettytime;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrettyTimeI18n_PL_Test
+{
+   private final SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy");
+   private Locale locale;
+
+   @Before
+   public void setUp() throws Exception
+   {
+      locale = new Locale("pl");
+      Locale.setDefault(locale);
+   }
+
+   @Test
+   public void testPrettyTime()
+   {
+      PrettyTime p = new PrettyTime(locale);
+      assertEquals("przed chwilą", p.format(new Date()));
+   }
+
+   @Test
+   public void testPrettyTimeCenturies()
+   {
+      PrettyTime p = new PrettyTime(new Date(3155692597470L * 3L), locale);
+      assertEquals("3 wieki temu", p.format(new Date(0)));
+
+      p = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 wieki", p.format(new Date(3155692597470L * 3L)));
+   }
+
+   @Test
+   public void testCeilingInterval() throws Exception
+   {
+      Date then = format.parse("20/5/2009");
+      Date ref = format.parse("17/6/2009");
+      PrettyTime t = new PrettyTime(ref, locale);
+      assertEquals("1 miesiąc temu", t.format(then));
+   }
+
+   @Test
+   public void testNullDate() throws Exception
+   {
+      PrettyTime t = new PrettyTime(locale);
+      Date date = null;
+      assertEquals("za chwilę", t.format(date));
+   }
+
+   @Test
+   public void testRightNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(locale);
+      assertEquals("za chwilę", t.format(new Date()));
+   }
+
+   @Test
+   public void testRightNowVariance() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za chwilę", t.format(new Date(600)));
+   }
+
+   @Test
+   public void testMinutesFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 12 minut", t.format(new Date(1000 * 60 * 12)));
+   }
+
+   @Test
+   public void testHoursFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 godziny", t.format(new Date(1000 * 60 * 60 * 3)));
+   }
+
+   @Test
+   public void testDaysFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 dni", t.format(new Date(1000 * 60 * 60 * 24 * 3)));
+   }
+
+   @Test
+   public void testWeeksFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 tygodnie", t.format(new Date(1000 * 60 * 60 * 24 * 7 * 3)));
+   }
+
+   @Test
+   public void testMonthsFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 miesiące", t.format(new Date(2629743830L * 3L)));
+   }
+
+   @Test
+   public void testYearsFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 lata", t.format(new Date(2629743830L * 12L * 3L)));
+   }
+
+   @Test
+   public void testDecadesFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 dekady", t.format(new Date(315569259747L * 3L)));
+   }
+
+   @Test
+   public void testCenturiesFromNow() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(0), locale);
+      assertEquals("za 3 wieki", t.format(new Date(3155692597470L * 3L)));
+   }
+
+   /*
+    * Past
+    */
+   @Test
+   public void testMomentsAgo() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(6000), locale);
+      assertEquals("przed chwilą", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMinutesAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60), locale);
+      assertEquals("1 minutę temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 minutę temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMinutesAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 3), locale);
+      assertEquals("3 minuty temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 minuty temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMinutesAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 12), locale);
+      assertEquals("12 minut temu", t.formatUnrounded(new Date(0)));
+      assertEquals("12 minut temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testHoursAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60), locale);
+      assertEquals("1 godzinę temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 godzinę temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testHoursAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 3), locale);
+      assertEquals("3 godziny temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 godziny temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testHoursAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 5), locale);
+      assertEquals("5 godzin temu", t.formatUnrounded(new Date(0)));
+      assertEquals("5 godzin temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDaysAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24), locale);
+      assertEquals("1 dzień temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 dzień temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDaysAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 3), locale);
+      assertEquals("3 dni temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 dni temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDaysAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 5), locale);
+      assertEquals("5 dni temu", t.formatUnrounded(new Date(0)));
+      assertEquals("5 dni temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testWeeksAgo() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 7), locale);
+      assertEquals("1 tydzień temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 tydzień temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testWeeksAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 7 * 3), locale);
+      assertEquals("3 tygodnie temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 tygodnie temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMonthsAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L), locale);
+      assertEquals("1 miesiąc temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 miesiąc temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMonthsAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 3L), locale);
+      assertEquals("3 miesiące temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 miesiące temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testMonthsAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 5L), locale);
+      assertEquals("5 miesięcy temu", t.formatUnrounded(new Date(0)));
+      assertEquals("5 miesięcy temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testYearsAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 12L), locale);
+      assertEquals("1 rok temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 rok temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testYearsAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 12L * 3L), locale);
+      assertEquals("3 lata temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 lata temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testYearsAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(2629743830L * 12L * 5L), locale);
+      assertEquals("5 lat temu", t.formatUnrounded(new Date(0)));
+      assertEquals("5 lat temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDecadesAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(315569259747L), locale);
+      assertEquals("1 dekadę temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 dekadę temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDecadesAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(315569259747L * 3L), locale);
+      assertEquals("3 dekady temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 dekady temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testDecadesAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(315569259747L * 5L), locale);
+      assertEquals("5 dekad temu", t.formatUnrounded(new Date(0)));
+      assertEquals("5 dekad temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testCenturiesAgo1() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(3155692597470L), locale);
+      assertEquals("1 wiek temu", t.formatUnrounded(new Date(0)));
+      assertEquals("1 wiek temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testCenturiesAgo2() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(3155692597470L * 3L), locale);
+      assertEquals("3 wieki temu", t.formatUnrounded(new Date(0)));
+      assertEquals("3 wieki temu", t.format(new Date(0)));
+   }
+
+   @Test
+   public void testCenturiesAgo3() throws Exception
+   {
+      PrettyTime t = new PrettyTime(new Date(3155692597470L * 5L), locale);
+      assertEquals("5 wieków temu", t.formatUnrounded(new Date(0)));
+      assertEquals("5 wieków temu", t.format(new Date(0)));
+   }
+
+   @After
+   public void tearDown() throws Exception
+   {
+      Locale.setDefault(locale);
+   }
+}


### PR DESCRIPTION
Hi,

I've added support for plural forms in Polish language, because displaying always alternative forms looked wrong. Code is based on the one from Russian locale, since our languages are very similar. I've also expanded some abbreviations, because I don't know why they were originally used, maybe to cover the wrong plural forms, and they also weren't looking nice.
To ensure that everything's working fine, I've also added some unit tests (also similar to Russian ones).