### PR TITLE
Enforce code formatting of changed files

### DIFF
--- a/config/license-header.txt
+++ b/config/license-header.txt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/config/ocpsoft-eclipse-code-format.xml
+++ b/config/ocpsoft-eclipse-code-format.xml
@@ -1,0 +1,795 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+	<profile kind="CodeFormatterProfile" name="OCPSoft" version="12">
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.disabling_tag"
+			value="@formatter:off" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration"
+			value="end_of_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field"
+			value="0" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line"
+			value="false" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression"
+			value="80" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer"
+			value="end_of_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.continuation_indentation"
+			value="3" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package"
+			value="0" />
+		<setting id="org.eclipse.jdt.core.compiler.source" value="1.5" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.align_type_members_on_columns"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment"
+			value="false" />
+		<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration"
+			value="0" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.indentation.size"
+			value="3" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.enabling_tag"
+			value="@formatter:on" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration"
+			value="0" />
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment"
+			value="0" />
+		<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier"
+			value="error" />
+		<setting id="org.eclipse.jdt.core.formatter.tabulation.char"
+			value="space" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body"
+			value="true" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration"
+			value="next_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration"
+			value="0" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch"
+			value="next_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier"
+			value="error" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch"
+			value="false" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block"
+			value="end_of_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration"
+			value="next_line" />
+		<setting id="org.eclipse.jdt.core.formatter.compact_else_if"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant"
+			value="next_line" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.tabulation.size"
+			value="3" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case"
+			value="next_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.5" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer"
+			value="3" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration"
+			value="next_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode"
+			value="enabled" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line"
+			value="false" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments"
+			value="true" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.line_length"
+			value="120" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration"
+			value="next_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body"
+			value="0" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration"
+			value="16" />
+		<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_html"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration"
+			value="16" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer"
+			value="insert" />
+		<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform"
+			value="1.5" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation"
+			value="0" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_header"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.format_block_comments"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants"
+			value="0" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration"
+			value="next_line" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries"
+			value="true" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports"
+			value="1" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header"
+			value="true" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for"
+			value="insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments"
+			value="do not insert" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column"
+			value="false" />
+		<setting
+			id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line"
+			value="false" />
+	</profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,39 @@
 					</checkModificationExcludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.13.0</version>
+				<!-- see https://github.com/diffplug/spotless/tree/main/plugin-maven -->
+				<configuration>
+					<!-- enforce formatting only for files that have changed -->
+					<ratchetFrom>origin/master</ratchetFrom>
+					<formats>
+						<format>
+							<includes>
+								<include>*.xml</include>
+								<include>*.md</include>
+								<include>.gitignore</include>
+							</includes>
+							<trimTrailingWhitespace/>
+							<endWithNewline/>
+							<indent>
+								<tabs>true</tabs>
+								<spacesPerTab>4</spacesPerTab>
+							</indent>
+						</format>
+					</formats>
+					<java>
+						<eclipse>
+							<file>${session.executionRootDirectory}/config/ocpsoft-eclipse-code-format.xml</file>
+						</eclipse>
+						<licenseHeader>
+							<file>${session.executionRootDirectory}/config/license-header.txt</file>
+						</licenseHeader>
+					</java>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This commit introduces the maven spotless plugin to the project
that can format the source code using "mvn spotless:apply" based
on the configuration in the parent pom.xml.
Also it will perform a spotless:check during the verify phase
to ensure that all files are properly formatted.