### PR TITLE
fix(sec): upgrade jetty-server to 11.0.10

### DIFF
--- a/samples/jstl/pom.xml
+++ b/samples/jstl/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>10.0.10</version>
+            <version>11.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Upgrade jetty-server from 10.0.10 to 11.0.10 for vulnerability fix:
- [CVE-2022-2191](https://www.oscs1024.com/hd/MPS-2022-19808)