### PR TITLE
Add support for the ChronoUnit enum.

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
@@ -15,38 +15,17 @@
  */
 package org.ocpsoft.prettytime;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.ocpsoft.prettytime.impl.DurationImpl;
 import org.ocpsoft.prettytime.impl.ResourcesTimeFormat;
 import org.ocpsoft.prettytime.impl.ResourcesTimeUnit;
-import org.ocpsoft.prettytime.units.Century;
-import org.ocpsoft.prettytime.units.Day;
-import org.ocpsoft.prettytime.units.Decade;
-import org.ocpsoft.prettytime.units.Hour;
-import org.ocpsoft.prettytime.units.JustNow;
-import org.ocpsoft.prettytime.units.Millennium;
-import org.ocpsoft.prettytime.units.Millisecond;
-import org.ocpsoft.prettytime.units.Minute;
 import org.ocpsoft.prettytime.units.Month;
-import org.ocpsoft.prettytime.units.Second;
-import org.ocpsoft.prettytime.units.Week;
 import org.ocpsoft.prettytime.units.Year;
+import org.ocpsoft.prettytime.units.*;
+
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A utility for creating social-networking style timestamps. (e.g. "just now", "moments ago", "3 days ago", "within 2
@@ -1465,6 +1444,20 @@ public class PrettyTime
    }
 
    /**
+    * Get the registered {@link TimeUnit} for the given {@link ChronoUnit} type or {@code null}
+    * if none exists.
+    *
+    * @param unit The {@code ChronoUnit}
+    * @return the time unit
+    * @throws IllegalArgumentException if no corresponding {@code TimeUnit} was found for the given
+    * {@code ChronoUnit}
+    */
+   public TimeUnit getUnit(final ChronoUnit unit)
+   {
+      return getUnit(TimeUnit.of(unit).getClass());
+   }
+
+   /**
     * Register the given {@link TimeUnit} and corresponding {@link TimeFormat} instance to be used in calculations. If
     * an entry already exists for the given {@link TimeUnit}, its {@link TimeFormat} will be overwritten with the given
     * {@link TimeFormat}. ({@link TimeUnit} and {@link TimeFormat} must not be <code>null</code>.)
@@ -1480,6 +1473,19 @@ public class PrettyTime
       if (format instanceof LocaleAware)
          ((LocaleAware<?>) format).setLocale(locale);
       return this;
+   }
+
+   /**
+    * Register the given {@link ChronoUnit} and corresponding {@link TimeFormat}.
+    * @param unit The {@code ChronoUnit} to be registered
+    * @param format The {@code TimeFormat} to be registered
+    * @return the current {@code PrettyTime} object
+    * @throws IllegalArgumentException if no corresponding {@code TimeUnit} was found for the given
+    * {@code ChronoUnit}
+    */
+   public PrettyTime registerUnit(final ChronoUnit unit, final TimeFormat format)
+   {
+      return registerUnit(TimeUnit.of(unit), format);
    }
 
    public PrettyTime setUnits(final ResourcesTimeUnit... units)
@@ -1543,6 +1549,20 @@ public class PrettyTime
       cachedUnits = null;
 
       return units.remove(unit);
+   }
+
+   /**
+    * Removes the mapping corresponding to the given {@link ChronoUnit}, returning the
+    * {@link TimeFormat} if available.
+    *
+    * @param unit The {@code ChronoUnit} to be removed
+    * @return the corresponding {@code TimeFormat}
+    * @throws IllegalArgumentException if no {@link TimeUnit} corresponding to the given
+    * {@code ChronoUnit} was found.
+    */
+   public TimeFormat removeUnit(final ChronoUnit unit)
+   {
+      return removeUnit(TimeUnit.of(unit));
    }
 
    /**

--- a/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/PrettyTime.java
@@ -15,17 +15,39 @@
  */
 package org.ocpsoft.prettytime;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.ocpsoft.prettytime.impl.DurationImpl;
 import org.ocpsoft.prettytime.impl.ResourcesTimeFormat;
 import org.ocpsoft.prettytime.impl.ResourcesTimeUnit;
+import org.ocpsoft.prettytime.units.Century;
+import org.ocpsoft.prettytime.units.Day;
+import org.ocpsoft.prettytime.units.Decade;
+import org.ocpsoft.prettytime.units.Hour;
+import org.ocpsoft.prettytime.units.JustNow;
+import org.ocpsoft.prettytime.units.Millennium;
+import org.ocpsoft.prettytime.units.Millisecond;
+import org.ocpsoft.prettytime.units.Minute;
 import org.ocpsoft.prettytime.units.Month;
+import org.ocpsoft.prettytime.units.Second;
+import org.ocpsoft.prettytime.units.Week;
 import org.ocpsoft.prettytime.units.Year;
-import org.ocpsoft.prettytime.units.*;
-
-import java.time.*;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A utility for creating social-networking style timestamps. (e.g. "just now", "moments ago", "3 days ago", "within 2

--- a/core/src/main/java/org/ocpsoft/prettytime/TimeUnit.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/TimeUnit.java
@@ -15,7 +15,17 @@
  */
 package org.ocpsoft.prettytime;
 
-import org.ocpsoft.prettytime.units.*;
+import org.ocpsoft.prettytime.units.Century;
+import org.ocpsoft.prettytime.units.Day;
+import org.ocpsoft.prettytime.units.Decade;
+import org.ocpsoft.prettytime.units.Hour;
+import org.ocpsoft.prettytime.units.Millennium;
+import org.ocpsoft.prettytime.units.Millisecond;
+import org.ocpsoft.prettytime.units.Minute;
+import org.ocpsoft.prettytime.units.Month;
+import org.ocpsoft.prettytime.units.Second;
+import org.ocpsoft.prettytime.units.Week;
+import org.ocpsoft.prettytime.units.Year;
 
 import java.time.temporal.ChronoUnit;
 

--- a/core/src/main/java/org/ocpsoft/prettytime/TimeUnit.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/TimeUnit.java
@@ -15,6 +15,10 @@
  */
 package org.ocpsoft.prettytime;
 
+import org.ocpsoft.prettytime.units.*;
+
+import java.time.temporal.ChronoUnit;
+
 /**
  * Defines a Unit of time (e.g. seconds, minutes, hours) and its conversion to milliseconds.
  * 
@@ -47,4 +51,74 @@ public interface TimeUnit
     * "minute" as opposed to "moment".
     */
    public boolean isPrecise();
+
+   /**
+    * Converts the given {@link ChronoUnit} to a {@link TimeUnit}, if possible.
+    * @param chronoUnit The {@code ChronoUnit} to be converted
+    * @return the corresponding {@code TimeUnit}
+    * @throws IllegalArgumentException if there is no corresponding {@code TimeUnit}
+    */
+   public static TimeUnit of(final ChronoUnit chronoUnit) {
+      switch (chronoUnit) {
+         case MILLIS:
+            return new Millisecond();
+         case SECONDS:
+            return new Second();
+         case MINUTES:
+            return new Minute();
+         case HOURS:
+            return new Hour();
+         case DAYS:
+            return new Day();
+         case WEEKS:
+            return new Week();
+         case MONTHS:
+            return new Month();
+         case YEARS:
+            return new Year();
+         case DECADES:
+            return new Decade();
+         case CENTURIES:
+            return new Century();
+         case MILLENNIA:
+            return new Millennium();
+         default:
+            throw new IllegalArgumentException("No corresponding TimeUnit for given ChronoUnit");
+      }
+   }
+
+   /**
+    * Converts the given {@link TimeUnit} to a {@link ChronoUnit}, if possible.
+    *
+    * @param timeUnit The {@code TimeUnit} to be converted
+    * @return the corresponding {@code ChronoUnit}
+    * @throws IllegalArgumentException if there is no corresponding {@code ChronoUnit}.
+    */
+   public static ChronoUnit toChronoUnit(final TimeUnit timeUnit) {
+      if (timeUnit instanceof Millisecond) {
+         return ChronoUnit.MILLIS;
+      } else if (timeUnit instanceof Second) {
+         return ChronoUnit.SECONDS;
+      } else if (timeUnit instanceof Minute) {
+         return ChronoUnit.MINUTES;
+      } else if (timeUnit instanceof Hour) {
+         return ChronoUnit.HOURS;
+      } else if (timeUnit instanceof Day) {
+         return ChronoUnit.DAYS;
+      } else if (timeUnit instanceof Week) {
+         return ChronoUnit.WEEKS;
+      } else if (timeUnit instanceof Month) {
+         return ChronoUnit.MONTHS;
+      } else if (timeUnit instanceof Year) {
+         return ChronoUnit.YEARS;
+      } else if (timeUnit instanceof Decade) {
+         return ChronoUnit.DECADES;
+      } else if (timeUnit instanceof Century) {
+         return ChronoUnit.CENTURIES;
+      } else if (timeUnit instanceof Millennium) {
+         return ChronoUnit.MILLENNIA;
+      } else {
+         throw new IllegalArgumentException("No corresponding ChronoUnit for given TimeUnit");
+      }
+   }
 }

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeAPIManipulationTest.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeAPIManipulationTest.java
@@ -15,21 +15,17 @@
  */
 package org.ocpsoft.prettytime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ocpsoft.prettytime.units.JustNow;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.ocpsoft.prettytime.units.JustNow;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PrettyTimeAPIManipulationTest
 {
@@ -244,7 +240,7 @@ public class PrettyTimeAPIManipulationTest
    @Test(expected = NullPointerException.class)
    public void testApiMisuse14() throws Exception
    {
-      t.registerUnit(null, null);
+      t.registerUnit((TimeUnit) null, null);
    }
 
    @Test
@@ -268,7 +264,7 @@ public class PrettyTimeAPIManipulationTest
    @Test
    public void testApiMisuse18() throws Exception
    {
-      Assert.assertNull(t.getUnit(null));
+      Assert.assertNull(t.getUnit((Class<TimeUnit>) null));
    }
 
    @Test

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeAPIManipulationTest.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeAPIManipulationTest.java
@@ -15,17 +15,22 @@
  */
 package org.ocpsoft.prettytime;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.ocpsoft.prettytime.units.JustNow;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ocpsoft.prettytime.units.JustNow;
 
 public class PrettyTimeAPIManipulationTest
 {
@@ -238,9 +243,15 @@ public class PrettyTimeAPIManipulationTest
    }
 
    @Test(expected = NullPointerException.class)
-   public void testApiMisuse14() throws Exception
+   public void testApiMisuse14_TimeUnit() throws Exception
    {
       t.registerUnit((TimeUnit) null, null);
+   }
+
+   @Test(expected = NullPointerException.class)
+   public void testApiMisuse14_ChronoUnit()
+   {
+      t.registerUnit((ChronoUnit) null, null);
    }
 
    @Test


### PR DESCRIPTION
Refactors the code to make use of `java.time`'s [`ChronoUnit`](https://docs.oracle.com/javase/8/docs/api/java/time/temporal/ChronoUnit.html) enum. (Issue #247)