### PR TITLE
Fix for formatDuration method for russian locale

### DIFF
--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ru.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ru.java
@@ -34,20 +34,19 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
 
       @Override
       public String format(Duration duration) {
-         String time = String.valueOf(Math.abs(duration.getQuantityRounded(tolerance)));
-         return performFormat(duration, time, true);
+         long roundedQuantity = Math.abs(duration.getQuantityRounded(tolerance));
+         return performFormat(roundedQuantity, true);
       }
 
       @Override
       public String formatUnrounded(Duration duration) {
-         String time = String.valueOf(Math.abs(duration.getQuantity()));
-         return performFormat(duration, time, true);
+         long unroundedQuantity = Math.abs(duration.getQuantity());
+         return performFormat(unroundedQuantity, true);
       }
 
-      public String performFormat(Duration duration, String time, boolean isDuration) {
+      public String performFormat(long n, boolean isDuration) {
          // a bit cryptic, yet well-tested
          // consider http://translate.sourceforge.net/wiki/l10n/pluralforms
-         long n = Math.abs(duration.getQuantity());
          int pluralIdx = (n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4
                   && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
 
@@ -56,7 +55,7 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
             throw new IllegalStateException("Wrong plural index was calculated somehow for russian language");
          }
 
-         String result = time +
+         String result = String.valueOf(n) +
                  ' ' +
                  pluarls[isDuration && pluralIdx == 0 ? pluralIdx : pluralIdx + 1];
 
@@ -66,8 +65,8 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
       @Override
       public String decorate(Duration duration, String time) {
          if(requiresReformatting(duration, true)) {
-            time = String.valueOf(Math.abs(duration.getQuantityRounded(tolerance)));
-            return performDecoration(duration, performFormat(duration, time, false));
+            long roundedQuantity = Math.abs(duration.getQuantityRounded(tolerance));
+            return performDecoration(duration, performFormat(roundedQuantity, false));
          }
          return performDecoration(duration, time);
       }
@@ -75,8 +74,8 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
       @Override
       public String decorateUnrounded(Duration duration, String time) {
          if(requiresReformatting(duration, false)) {
-            time = String.valueOf(Math.abs(duration.getQuantity()));
-            return performDecoration(duration, performFormat(duration, time, false));
+            long unroundedQuantity = Math.abs(duration.getQuantity());
+            return performDecoration(duration, performFormat(unroundedQuantity, false));
          }
          return performDecoration(duration, time);
       }

--- a/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ru.java
+++ b/core/src/main/java/org/ocpsoft/prettytime/i18n/Resources_ru.java
@@ -6,6 +6,7 @@ import org.ocpsoft.prettytime.TimeUnit;
 import org.ocpsoft.prettytime.impl.TimeFormatProvider;
 import org.ocpsoft.prettytime.units.*;
 
+import java.util.Arrays;
 import java.util.ListResourceBundle;
 
 /**
@@ -18,83 +19,92 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
    private static final int tolerance = 50;
 
    // see http://translate.sourceforge.net/wiki/l10n/pluralforms
-   private static final int russianPluralForms = 3;
+   private static final int russianPluralForms = 4;
 
-   private static class TimeFormatAided implements TimeFormat
-   {
+   private class TimeFormatAided implements TimeFormat {
       private final String[] pluarls;
 
-      public TimeFormatAided(String... plurals)
-      {
+      public TimeFormatAided(String... plurals) {
          if (plurals.length != russianPluralForms) {
-            throw new IllegalArgumentException("Wrong plural forms number for russian language!");
+            throw new IllegalArgumentException(String.format("Wrong plural forms number for russian language! " +
+                    "Expected %s, got %s\nPlurals: %s", russianPluralForms, plurals.length, Arrays.toString(plurals)));
          }
          this.pluarls = plurals;
       }
 
       @Override
-      public String format(Duration duration)
-      {
-         long quantity = duration.getQuantityRounded(tolerance);
-         return String.valueOf(quantity);
+      public String format(Duration duration) {
+         String time = String.valueOf(Math.abs(duration.getQuantityRounded(tolerance)));
+         return performFormat(duration, time, true);
       }
 
       @Override
-      public String formatUnrounded(Duration duration)
-      {
-         long quantity = Math.abs(duration.getQuantity());
-         return String.valueOf(quantity);
+      public String formatUnrounded(Duration duration) {
+         String time = String.valueOf(Math.abs(duration.getQuantity()));
+         return performFormat(duration, time, true);
       }
 
-      @Override
-      public String decorate(Duration duration, String time)
-      {
-         return performDecoration(
-                  duration.isInPast(),
-                  duration.isInFuture(),
-                  duration.getQuantityRounded(tolerance),
-                  time);
-      }
-
-      @Override
-      public String decorateUnrounded(Duration duration, String time)
-      {
-         return performDecoration(
-                  duration.isInPast(),
-                  duration.isInFuture(),
-                  Math.abs(duration.getQuantity()),
-                  time);
-      }
-
-      private String performDecoration(boolean past, boolean future, long n, String time)
-      {
+      public String performFormat(Duration duration, String time, boolean isDuration) {
          // a bit cryptic, yet well-tested
          // consider http://translate.sourceforge.net/wiki/l10n/pluralforms
+         long n = Math.abs(duration.getQuantity());
          int pluralIdx = (n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4
                   && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
+
          if (pluralIdx > russianPluralForms) {
             // impossible happening
             throw new IllegalStateException("Wrong plural index was calculated somehow for russian language");
          }
 
-         StringBuilder result = new StringBuilder();
+         String result = time +
+                 ' ' +
+                 pluarls[isDuration && pluralIdx == 0 ? pluralIdx : pluralIdx + 1];
 
-         if (future) {
-            result.append("через ");
+         return result;
+      }
+
+      @Override
+      public String decorate(Duration duration, String time) {
+         if(requiresReformatting(duration, true)) {
+            time = String.valueOf(Math.abs(duration.getQuantityRounded(tolerance)));
+            return performDecoration(duration, performFormat(duration, time, false));
          }
+         return performDecoration(duration, time);
+      }
 
-         result.append(time);
-         result.append(' ');
-         result.append(pluarls[pluralIdx]);
-
-         if (past) {
-            result.append(" назад");
+      @Override
+      public String decorateUnrounded(Duration duration, String time) {
+         if(requiresReformatting(duration, false)) {
+            time = String.valueOf(Math.abs(duration.getQuantity()));
+            return performDecoration(duration, performFormat(duration, time, false));
          }
+         return performDecoration(duration, time);
+      }
 
-         return result.toString();
+      public String performDecoration(Duration duration, String time) {
+         if (duration.isInFuture()) {
+            return "через " + time;
+         }
+         if (duration.isInPast()) {
+            return time + " назад";
+         }
+         return time;
+      }
+
+      /**
+       * While in English format can be achieved by simply adding " ago" to formatDuration result,
+       * in Russian there's difference: "1 minute" is "1 минута" but "1 minute ago" is "1 минуту назад"
+       * see here: <a href="https://www.thoughtco.com/russian-cases-4768614">article about russian grammatical cases</a>
+       * This hacky method checks if it's the case when result of format method should be corrected.
+       * @param duration The original {@link Duration} instance from which the time string should be decorated.
+       * @param isRounded Determines whether rounded quantity be checked or plain one
+       * @return Is reformatting required (is case "1 минута" - "1 минуту назад" - "через 1 минуту" reached)
+       */
+      public boolean requiresReformatting(Duration duration, boolean isRounded) {
+         long quantity = isRounded ? Math.abs(duration.getQuantityRounded(tolerance)) : Math.abs(duration.getQuantity());
+         return quantity == 1;
       }
    }
-
    @Override
    public Object[][] getContents()
    {
@@ -129,6 +139,8 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
                return null;
             }
 
+
+
             @Override
             public String decorate(Duration duration, String time)
             {
@@ -143,37 +155,37 @@ public class Resources_ru extends ListResourceBundle implements TimeFormatProvid
          };
       }
       else if (t instanceof Century) {
-         return new TimeFormatAided("век", "века", "веков");
+         return new TimeFormatAided("век", "век", "века", "веков");
       }
       else if (t instanceof Day) {
-         return new TimeFormatAided("день", "дня", "дней");
+         return new TimeFormatAided("день", "день", "дня", "дней");
       }
       else if (t instanceof Decade) {
-         return new TimeFormatAided("десятилетие", "десятилетия", "десятилетий");
+         return new TimeFormatAided("десятилетие", "десятилетие", "десятилетия", "десятилетий");
       }
       else if (t instanceof Hour) {
-         return new TimeFormatAided("час", "часа", "часов");
+         return new TimeFormatAided("час", "час", "часа", "часов");
       }
       else if (t instanceof Millennium) {
-         return new TimeFormatAided("тысячелетие", "тысячелетия", "тысячелетий");
+         return new TimeFormatAided("тысячелетие", "тысячелетие", "тысячелетия", "тысячелетий");
       }
       else if (t instanceof Millisecond) {
-         return new TimeFormatAided("миллисекунду", "миллисекунды", "миллисекунд");
+         return new TimeFormatAided("миллисекунда", "миллисекунду", "миллисекунды", "миллисекунд");
       }
       else if (t instanceof Minute) {
-         return new TimeFormatAided("минуту", "минуты", "минут");
+         return new TimeFormatAided("минута", "минуту", "минуты", "минут");
       }
       else if (t instanceof Month) {
-         return new TimeFormatAided("месяц", "месяца", "месяцев");
+         return new TimeFormatAided("месяц", "месяц", "месяца", "месяцев");
       }
       else if (t instanceof Second) {
-         return new TimeFormatAided("секунду", "секунды", "секунд");
+         return new TimeFormatAided("секунда", "секунду", "секунды", "секунд");
       }
       else if (t instanceof Week) {
-         return new TimeFormatAided("неделю", "недели", "недель");
+         return new TimeFormatAided("неделя", "неделю", "недели", "недель");
       }
       else if (t instanceof Year) {
-         return new TimeFormatAided("год", "года", "лет");
+         return new TimeFormatAided("год", "год", "года", "лет");
       }
       return null; // error
    }

--- a/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_RU_Test.java
+++ b/core/src/test/java/org/ocpsoft/prettytime/PrettyTimeI18n_RU_Test.java
@@ -1,10 +1,10 @@
 package org.ocpsoft.prettytime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -29,7 +29,8 @@ public class PrettyTimeI18n_RU_Test
    public void testPrettyTime()
    {
       PrettyTime p = new PrettyTime(locale);
-      assertEquals("сейчас", p.format(new Date()));
+      List<String> values = Arrays.asList("сейчас", "только что");
+      assertTrue(values.contains(p.format(new Date())));
    }
 
    @Test
@@ -37,9 +38,11 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime p = new PrettyTime(new Date(3155692597470L * 3L), locale);
       assertEquals("3 века назад", p.format(new Date(0)));
+      assertEquals("3 века", p.formatDuration(new Date(0)));
 
       p = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 века", p.format(new Date(3155692597470L * 3L)));
+      assertEquals("3 века", p.formatDuration(new Date(3155692597470L * 3L)));
    }
 
    @Test
@@ -49,6 +52,7 @@ public class PrettyTimeI18n_RU_Test
       Date ref = format.parse("17/6/2009");
       PrettyTime t = new PrettyTime(ref, locale);
       assertEquals("1 месяц назад", t.format(then));
+      assertEquals("1 месяц", t.formatDuration(then));
    }
 
    @Test
@@ -57,6 +61,7 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(locale);
       Date date = null;
       assertEquals("сейчас", t.format(date));
+      assertEquals("сейчас", t.formatDuration(date));
    }
 
    @Test
@@ -64,6 +69,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(locale);
       assertEquals("сейчас", t.format(new Date()));
+      assertEquals("сейчас", t.formatDuration(new Date()));
    }
 
    @Test
@@ -71,6 +77,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("сейчас", t.format(new Date(600)));
+      assertEquals("сейчас", t.formatDuration(new Date(600)));
    }
 
    @Test
@@ -78,6 +85,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 12 минут", t.format(new Date(1000 * 60 * 12)));
+      assertEquals("12 минут", t.formatDuration(new Date(1000 * 60 * 12)));
    }
 
    @Test
@@ -85,6 +93,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 часа", t.format(new Date(1000 * 60 * 60 * 3)));
+      assertEquals("3 часа", t.formatDuration(new Date(1000 * 60 * 60 * 3)));
    }
 
    @Test
@@ -92,6 +101,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 дня", t.format(new Date(1000 * 60 * 60 * 24 * 3)));
+      assertEquals("3 дня", t.formatDurationUnrounded(new Date(1000 * 60 * 60 * 24 * 3)));
    }
 
    @Test
@@ -99,6 +109,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 недели", t.format(new Date(1000 * 60 * 60 * 24 * 7 * 3)));
+      assertEquals("3 недели", t.formatDuration(new Date(1000 * 60 * 60 * 24 * 7 * 3)));
    }
 
    @Test
@@ -106,6 +117,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 месяца", t.format(new Date(2629743830L * 3L)));
+      assertEquals("3 месяца", t.formatDuration(new Date(2629743830L * 3L)));
    }
 
    @Test
@@ -113,6 +125,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 года", t.format(new Date(2629743830L * 12L * 3L)));
+      assertEquals("3 года", t.formatDuration(new Date(2629743830L * 12L * 3L)));
    }
 
    @Test
@@ -120,6 +133,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 десятилетия", t.format(new Date(315569259747L * 3L)));
+      assertEquals("3 десятилетия", t.formatDuration(new Date(315569259747L * 3L)));
    }
 
    @Test
@@ -127,6 +141,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(0), locale);
       assertEquals("через 3 века", t.format(new Date(3155692597470L * 3L)));
+      assertEquals("3 века", t.formatDuration(new Date(3155692597470L * 3L)));
    }
 
    /*
@@ -137,6 +152,7 @@ public class PrettyTimeI18n_RU_Test
    {
       PrettyTime t = new PrettyTime(new Date(6000), locale);
       assertEquals("только что", t.format(new Date(0)));
+      assertEquals("только что", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -145,6 +161,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60), locale);
       assertEquals("1 минуту назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 минуту назад", t.format(new Date(0)));
+      assertEquals("1 минута", t.formatDuration(new Date(0)));
+      assertEquals("1 минута", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -161,6 +179,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 12), locale);
       assertEquals("12 минут назад", t.formatUnrounded(new Date(0)));
       assertEquals("12 минут назад", t.format(new Date(0)));
+      assertEquals("12 минут", t.formatDuration(new Date(0)));
+      assertEquals("12 минут", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -169,6 +189,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60), locale);
       assertEquals("1 час назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 час назад", t.format(new Date(0)));
+      assertEquals("1 час", t.formatDuration(new Date(0)));
+      assertEquals("1 час", t.formatDurationUnrounded(new Date(0)));
    }
 
    @Test
@@ -177,6 +199,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 3), locale);
       assertEquals("3 часа назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 часа назад", t.format(new Date(0)));
+      assertEquals("3 часа", t.formatDuration(new Date(0)));
+      assertEquals("3 часа", t.formatDurationUnrounded(new Date(0)));
    }
 
    @Test
@@ -185,6 +209,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 5), locale);
       assertEquals("5 часов назад", t.formatUnrounded(new Date(0)));
       assertEquals("5 часов назад", t.format(new Date(0)));
+      assertEquals("5 часов", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("5 часов", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -193,6 +219,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24), locale);
       assertEquals("1 день назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 день назад", t.format(new Date(0)));
+      assertEquals("1 день", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("1 день", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -201,6 +229,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 3), locale);
       assertEquals("3 дня назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 дня назад", t.format(new Date(0)));
+      assertEquals("3 дня", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("3 дня", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -209,6 +239,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 5), locale);
       assertEquals("5 дней назад", t.formatUnrounded(new Date(0)));
       assertEquals("5 дней назад", t.format(new Date(0)));
+      assertEquals("5 дней", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("5 дней", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -217,6 +249,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 7), locale);
       assertEquals("1 неделю назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 неделю назад", t.format(new Date(0)));
+      assertEquals("1 неделя", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("1 неделя", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -225,6 +259,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(1000 * 60 * 60 * 24 * 7 * 3), locale);
       assertEquals("3 недели назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 недели назад", t.format(new Date(0)));
+      assertEquals("3 недели", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("3 недели", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -233,6 +269,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(2629743830L), locale);
       assertEquals("1 месяц назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 месяц назад", t.format(new Date(0)));
+      assertEquals("1 месяц", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("1 месяц", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -241,6 +279,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(2629743830L * 3L), locale);
       assertEquals("3 месяца назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 месяца назад", t.format(new Date(0)));
+      assertEquals("3 месяца", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("3 месяца", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -249,6 +289,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(2629743830L * 5L), locale);
       assertEquals("5 месяцев назад", t.formatUnrounded(new Date(0)));
       assertEquals("5 месяцев назад", t.format(new Date(0)));
+      assertEquals("5 месяцев", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("5 месяцев", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -257,6 +299,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(2629743830L * 12L), locale);
       assertEquals("1 год назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 год назад", t.format(new Date(0)));
+      assertEquals("1 год", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("1 год", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -265,6 +309,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(2629743830L * 12L * 3L), locale);
       assertEquals("3 года назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 года назад", t.format(new Date(0)));
+      assertEquals("3 года", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("3 года", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -273,6 +319,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(2629743830L * 12L * 5L), locale);
       assertEquals("5 лет назад", t.formatUnrounded(new Date(0)));
       assertEquals("5 лет назад", t.format(new Date(0)));
+      assertEquals("5 лет", t.formatDuration(new Date(0)));
+      assertEquals("5 лет", t.formatDurationUnrounded(new Date(0)));
    }
 
    @Test
@@ -289,6 +337,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(315569259747L * 3L), locale);
       assertEquals("3 десятилетия назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 десятилетия назад", t.format(new Date(0)));
+      assertEquals("3 десятилетия", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("3 десятилетия", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -297,6 +347,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(315569259747L * 5L), locale);
       assertEquals("5 десятилетий назад", t.formatUnrounded(new Date(0)));
       assertEquals("5 десятилетий назад", t.format(new Date(0)));
+      assertEquals("5 десятилетий", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("5 десятилетий", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -305,6 +357,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(3155692597470L), locale);
       assertEquals("1 век назад", t.formatUnrounded(new Date(0)));
       assertEquals("1 век назад", t.format(new Date(0)));
+      assertEquals("1 век", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("1 век", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -313,6 +367,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(3155692597470L * 3L), locale);
       assertEquals("3 века назад", t.formatUnrounded(new Date(0)));
       assertEquals("3 века назад", t.format(new Date(0)));
+      assertEquals("3 века", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("3 века", t.formatDuration(new Date(0)));
    }
 
    @Test
@@ -321,6 +377,8 @@ public class PrettyTimeI18n_RU_Test
       PrettyTime t = new PrettyTime(new Date(3155692597470L * 5L), locale);
       assertEquals("5 веков назад", t.formatUnrounded(new Date(0)));
       assertEquals("5 веков назад", t.format(new Date(0)));
+      assertEquals("5 веков", t.formatDurationUnrounded(new Date(0)));
+      assertEquals("5 веков", t.formatDuration(new Date(0)));
    }
 
    @After


### PR DESCRIPTION
This PR partly addresses issue #259 for russian language:

In english locale formatDuration() method works correctly returning "12 days"/"1 week"/"1 year" and etc. format() method also returns the correct thing: "12 days ago"/"in 1 week"/"1 year ago" but there's was a problem with russian locale:

while method format returned "12 дней назад" (12 days ago)/"1 минуту назад" (1 minute ago) there was a problem with formatDuration (and it wasn't even included in unit tests) - it returned String.valueOf(12) or "12"/"1" instead of desired "12 дней"/"1 минута"

This PR fixes this problem for russian locale.

Some work should still be done to support this for kk, uk, pl locales - these locales basically shared the same code.



P.S. In order to distinguish "1 минута" (or "1 minute") received by formatDuration from "через 1 минуту"/( or "in 1 minute") {there are some other cases of this but there are really few of them} i used a little bit hacky solution so some changes might be considered so format method would receive some hint whether result would be decorated or not. Not really important - just a small note (see comment in the code)