### PR TITLE
Create MRJAR with module-info.class

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,6 +14,25 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<configuration>
+							<excludes>
+								<exclude>module-info.java</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
@@ -27,6 +46,27 @@
 						<_exportcontents>org.ocpsoft.prettytime*</_exportcontents>
 					</instructions>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.Final</version>
+				<executions>
+					<execution>
+						<id>add-module-info</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<configuration>
+							<jvmVersion>9</jvmVersion>
+							<module>
+								<moduleInfoFile>${project.build.sourceDirectory}/module-info.java</moduleInfoFile>
+							</module>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module prettytime {
+    exports org.ocpsoft.prettytime;
+    exports org.ocpsoft.prettytime.format;
+    exports org.ocpsoft.prettytime.i18n;
+    exports org.ocpsoft.prettytime.impl;
+    exports org.ocpsoft.prettytime.units;
+    provides org.ocpsoft.prettytime.PrettyTime with org.ocpsoft.prettytime.PrettyTime;
+}


### PR DESCRIPTION
PR to issue #262

This creates a "Multi-Release JAR" (MRJAR). The generated jar works with Java 1.8 and Java >= 9.

For Java >= 9 a `module-info.class` is provided (`META-INF/versions/9/module-info.class`. This allows the usage of `jlink`-tool to generate custom java runtime images.