### PR TITLE
Moving slf4j to shade plugin

### DIFF
--- a/nlp/pom.xml
+++ b/nlp/pom.xml
@@ -62,6 +62,7 @@
 								<relocation>
 									<includes>
 										<include>com.joestelmach.**</include>
+										<include>org.slf4j.**</include>
 										<include>edu.emory.**</include>
 										<include>net.fortuna.**</include>
 										<include>org.antlr.**</include>


### PR DESCRIPTION
This is a fix related with https://github.com/ocpsoft/prettytime/issues/268
We are facing same problem, making our app to crash in runtime. This is a blocker for us. Can you please take a look to the change? It's just moving slf4j to the shade plugin so it's not conflicting with the other sl4j classes.